### PR TITLE
docs: add purpose of this repo to argue the use of this repo for authz

### DIFF
--- a/docs/decisions/0001-purpose-of-this-repo.rst
+++ b/docs/decisions/0001-purpose-of-this-repo.rst
@@ -25,6 +25,7 @@ This repository will serve as the central place for:
 - Architectural Decision Records (ADRs) that document the evolution of the authorization model.
 - Design documents for scopes, policies, and integration approaches.
 - Implementation of the new authorization framework which will eventually replace the legacy authorization system.
+- Utilities which will be imported by other services in the Open edX ecosystem to leverage the new authorization capabilities.
 - Migration strategies for replacing legacy RBAC models with this new system.
 
 Consequences


### PR DESCRIPTION
## Description

Add reasoning behind the decision to implement this project in a separate Django application instead of including it in the edx-platform directly. This is an early implementation decision, so it remains open to discussion until openly approved.
