### PR TITLE
docs: Add intersphinx mapping for OEPs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -513,6 +513,13 @@ epub_exclude_files = ["search.html"]
 #
 # epub_use_index = True
 
+# Intersphinx Extension Configuration
+DIGITS_ONLY = r"^\d+$"
+rtd_language = os.environ.get("READTHEDOCS_LANGUAGE", "en")
+rtd_version = os.environ.get("READTHEDOCS_VERSION", "latest")
+if re.search(DIGITS_ONLY, rtd_version):
+    # This is a PR build, use the latest versions of the other repos.
+    rtd_version = "latest"
 
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
@@ -522,6 +529,12 @@ intersphinx_mapping = {
         "https://docs.djangoproject.com/en/3.2/_objects/",
     ),
     "model_utils": ("https://django-model-utils.readthedocs.io/en/latest/", None),
+    "openedx-proposals": (
+        # Not setting the version on purpose because we always want the latest version
+        # of OEPs
+        f"https://docs.openedx.org/projects/openedx-proposals/{rtd_language}/latest",
+        None,
+    ),
 }
 
 

--- a/docs/decisions/0001-purpose-of-this-repo.rst
+++ b/docs/decisions/0001-purpose-of-this-repo.rst
@@ -48,4 +48,4 @@ References
 
 - Technical Approach: `AuthZ <https://openedx.atlassian.net/wiki/spaces/OEPM/pages/5176229910>`_
 - PRD: `Roles & Permissions <https://openedx.atlassian.net/wiki/spaces/OEPM/pages/4724490259>`_
-- OEP-66: `Authorization Best Practices <https://docs.openedx.org/projects/openedx-proposals/en/latest/best-practices/oep-0066-bp-authorization.html>`_
+- OEP-66: :ref:`Authorization Best Practices <openedx-proposals:OEP-66 User Authorization>`


### PR DESCRIPTION
Needed to find a little change to make to test the ReadTheDocs build 😅 

Adding the intersphinx mapping allows us to cross reference OEPs properly, reducing the chance that an OEP refactoring will break this docs build.