### PR TITLE
[FC-0099] docs: add ADR proposing how to manage the policy store 

### DIFF
--- a/docs/decisions/0006-policy-store-and-enforcement-model.rst
+++ b/docs/decisions/0006-policy-store-and-enforcement-model.rst
@@ -1,0 +1,95 @@
+0005: Policy Store and Casbin Configuration Model
+#################################################
+
+Status
+******
+**Draft**
+
+Context
+*******
+
+This ADR details how authorization policies are stored, versioned, and configured across the platform. It defines the Policy Store as the single source of truth, describes the relational database schema and metadata, and establishes naming conventions for subjects, actions, objects, and contexts. It also specifies the Casbin ``model.conf`` configuration, including the default matcher, allow/deny effects, static vs. dynamic policies, versioning rules, and how services ship and manage their ``authz.policy`` files.
+
+Decision
+********
+
+#. Authorization Engine Configuration
+=====================================
+
+Use a Casbin Model CONF that Supports Core Principles
+-----------------------------------------------------
+- Use a Casbin configuration model (``model.conf``) that supports Subject-Action-Object-Context checks, explicit scopes, and both RBAC and ABAC features.
+- Start supporting RBAC with roles and permissions, and evolve towards ABAC as needed to enable more granular and context-aware policies.
+- The ``model.conf`` file will be shared across all services unless explicitly overridden for a specific service.
+- The model configuration will be versioned and managed as part of the Open edX ecosystem to ensure consistency and traceability.
+- Favor simple matchers to improve performance and maintainability. This means avoiding complex regexes and nested logic where possible.
+- Explicitly define the effects of policies (allow/deny) and ensure that the default behavior is to deny unless explicitly allowed.
+- Use Casbin's built-in support for role hierarchies (g, g2) to manage role inheritance and simplify policy definitions.
+
+Use ``authz.policy`` Files for Default Policies
+-----------------------------------------------
+- Each service will ship with an ``authz.policy`` file that defines its default policies.
+- The ``authz.policy`` file will be loaded by the Open edX Layer at service initialization and saved in the policy store upon first load. They provide a baseline set of policies that ensure consistent behavior across deployments.
+- Default policies are immutable after load and provide a baseline set of policies that ensure consistent behavior across deployments.
+- Default policies should be subjected to load-testing to ensure they do not introduce performance regressions.
+
+Use a simplicity and clarity-first approach to Policy Definitions
+-----------------------------------------------------------------
+- Favor the use of simple and easy to read matchers and policies to keep the system maintainable. Revisit complexity if needed.
+- Define clear and consistent naming conventions for subjects, actions, objects, and contexts to ensure uniformity across services:
+  - Use namespaces to properly identify the subject, action, object, and context. For example, use ``org:123`` to refer to a specific org with ID 123. The exceptions for this rule are the objects that already have a namespace like ``course-v1:OpenedX+DemoX+DemoCourse`` or ``lib:DemoX:CSPROB``.
+  - Use singular verbs for actions (e.g., ``view``, ``edit``, ``delete``) with snake_case formatting when multiple words are needed (e.g., ``view_grades``, ``edit_content``).
+  - Use the username as the subject when referring to individual users (e.g., ``alice``, ``bob``).
+  - Use clear and descriptive names for roles. (e.g., ``course_admin``, ``content_creator``).
+- Use custom matchers to implement complex logic, but keep them as simple and reusable as possible.
+- Document all default policies with in-line comments in the ``authz.policy`` files to explain their purpose and usage.
+
+Roles are scoped to a specific context in the policy
+----------------------------------------------------
+- Grouping resources will not be implemented via Casbin's built-in role hierarchies (g, g2) but will be explicitly managed when checking permissions in the application layer. For example, if a user has the ``course_admin`` role in ``org:123``, this will not automatically grant them the ``course_admin`` role in all courses within that org. Instead, the application layer will need to check both the user's role and the specific context (e.g., organization or course) when making authorization decisions.
+- Define roles that are context-specific, such as ``course_admin`` for a specific course or ``org_admin`` for a specific organization.
+
+#. Policy Management and Versioning
+====================================
+
+Differentiate Between Static and Dynamic Policies
+-------------------------------------------------
+- Consider two types of policies: static policies (shipped with services in ``authz.policy`` files) and dynamic policies (created and managed via the Policy Management API and persisted in the policy store).
+- Dynamic policies can be created, updated, and deleted via the Policy Management API, allowing administrators to adapt policies to changing requirements without modifying service code.
+- Using dynamic policies allows for greater flexibility and adaptability, as policies can be modified in response to evolving business needs or security requirements. However, they might also introduce complexity and potential performance overhead if not defined and managed carefully.
+- Maintain a clear separation between static policies (shipped with services) and dynamic policies (managed via the policy data store).
+
+Version Static Policies and Make Dynamic Policies Immutable
+-----------------------------------------------------------
+- Version the ``authz.policy`` files with the service version to ensure that changes to static policies are tracked and can be rolled back if needed.
+- Dynamic policies created via the Policy Management API should be immutable once created. To change a dynamic policy, it should be deleted and recreated with the desired changes. This approach ensures that policy changes are auditable and traceable.
+- Implement auditing and logging for all policy changes, including who made the change, when it was made, and what the change was. This is crucial for maintaining security and compliance.
+
+#. Authorization Source of Truth and Clients Boundaries
+=======================================================
+
+Make the Policy Store the Single Source of Truth
+------------------------------------------------
+- The ``model.conf`` with the Casbin model configuration and the policy store (via MySQL adapter) together form the single source of truth for authorization in Open edX.
+- The policy store contains all dynamic policies and the static policies loaded from the ``authz.policy`` files at service initialization. The policy origin (static vs dynamic) can be tracked via metadata fields if needed.
+- The policy store is the single source of truth for authorization rules. By default, services share the same store to ensure consistency and avoid conflicts.
+
+Delegate Policy Ownership to Services
+-------------------------------------
+- Services are responsible for defining their own policies in the ``authz.policy`` files and managing their own dynamic policies via the Policy Management API.
+- These policies are managed by each service according to its domain. For example, the LMS manages courseware access policies, while the CMS manages content creation policies.
+- Authorization decisions must always be answered by the service that owns the relevant data and policies (policy owner). For instance, the LMS decides whether a user can access a course because it owns enrollments and courseware data. The CMS decides whether a user can edit content because it owns the content data.
+
+Enforce Consistency via the Open edX Layer
+------------------------------------------
+- Services do not maintain their own copies of policies or implement their own authorization logic. All authorization decisions are made by the Open edX Layer based on the policies in the policy store.
+
+Allow Shared or Separate Policy Stores as Needed
+------------------------------------------------
+- By default, all services share the same policy store to ensure consistency and avoid conflicts.
+- If isolation between services is required, this can be achieved in two ways: (1) by using a namespace or domain field in the shared table, or (2) by creating a separate policy store for a specific service.
+
+Consequences
+************
+
+#. **Clients Share the Same Policy Store**: By default, all services share the same policy store to ensure consistency and avoid conflicts. This means that policies defined by one service can affect authorization decisions in another service.

--- a/docs/decisions/0006-policy-store-and-enforcement-model.rst
+++ b/docs/decisions/0006-policy-store-and-enforcement-model.rst
@@ -37,8 +37,6 @@ Establish Naming Conventions for Subjects, Actions, Objects, and Contexts
   - Use singular verbs for actions (e.g., ``view``, ``edit``, ``delete``) with snake_case formatting when multiple words are needed (e.g., ``view_grades``, ``edit_content``).
   - Use the username as the subject when referring to individual users (e.g., ``alice``, ``bob``).
   - Use clear and descriptive names for roles. (e.g., ``course_admin``, ``content_creator``).
-- Use custom matchers to implement complex logic, but keep them as simple and reusable as possible.
-- Document all default policies with in-line comments in the ``authz.policy`` files to explain their purpose and usage.
 
 Use ``authz.policy`` Files for Default Policies
 -----------------------------------------------
@@ -46,6 +44,7 @@ Use ``authz.policy`` Files for Default Policies
 - The ``authz.policy`` file will be loaded by the Open edX Layer at service initialization and saved in the policy store upon first load. They provide a baseline set of policies that ensure consistent behavior across deployments.
 - Default policies should be subjected to load-testing to ensure they do not introduce performance regressions.
 - Services can override the default ``authz.policy`` file by providing a custom file path via configuration if needed.
+- Document all default policies with in-line comments in the ``authz.policy`` files to explain their purpose and usage.
 
 #. Policy Management and Versioning
 ====================================

--- a/docs/decisions/0006-policy-store-and-enforcement-model.rst
+++ b/docs/decisions/0006-policy-store-and-enforcement-model.rst
@@ -13,28 +13,24 @@ This ADR details how authorization policies are stored, versioned, and configure
 Decision
 ********
 
-#. Authorization Engine Configuration
-=====================================
+#. Authorization Engine Configuration (``model.conf`` & ``authz.policy``)
+=========================================================================
 
 Use a Casbin Model CONF that Supports Core Principles
 -----------------------------------------------------
 - Use a Casbin configuration model (``model.conf``) that supports Subject-Action-Object-Context checks, explicit scopes, and both RBAC and ABAC features.
-- Start supporting RBAC with roles and permissions, and evolve towards ABAC as needed to enable more granular and context-aware policies.
 - The ``model.conf`` file will be shared across all services unless explicitly overridden for a specific service.
-- The model configuration will be versioned and managed as part of the Open edX ecosystem to ensure consistency and traceability.
-- Favor simple matchers to improve performance and maintainability. This means avoiding complex regexes and nested logic where possible.
 - Explicitly define the effects of policies (allow/deny) and ensure that the default behavior is to deny unless explicitly allowed.
+- Favor simple matchers to improve performance and maintainability. This means avoiding complex regexes and nested logic where possible.
 - Use Casbin's built-in support for role hierarchies (g, g2) to manage role inheritance and simplify policy definitions.
 
-Use ``authz.policy`` Files for Default Policies
------------------------------------------------
-- Each service will ship with an ``authz.policy`` file that defines its default policies.
-- The ``authz.policy`` file will be loaded by the Open edX Layer at service initialization and saved in the policy store upon first load. They provide a baseline set of policies that ensure consistent behavior across deployments.
-- Default policies are immutable after load and provide a baseline set of policies that ensure consistent behavior across deployments.
-- Default policies should be subjected to load-testing to ensure they do not introduce performance regressions.
+Do not Handle Grouping and Context Inheritance via Casbin's Built-in Mechanisms
+-------------------------------------------------------------------------------
+- Grouping resources will not be implemented via Casbin's built-in grouping mechanisms (g, g2) but will be explicitly managed when checking permissions in the application layer. For example, if a user has the ``course_admin`` role in ``org:123``, this will not automatically grant them the ``course_admin`` role in all courses within that org. Instead, the application layer will need to check both the user's role and the specific context (e.g., organization or course) when making authorization decisions.
+- Define roles that are context-specific, such as ``course_admin`` for a specific course or ``org_admin`` for a specific organization.
 
-Use a simplicity and clarity-first approach to Policy Definitions
------------------------------------------------------------------
+Establish Naming Conventions for Subjects, Actions, Objects, and Contexts
+-------------------------------------------------------------------------
 - Favor the use of simple and easy to read matchers and policies to keep the system maintainable. Revisit complexity if needed.
 - Define clear and consistent naming conventions for subjects, actions, objects, and contexts to ensure uniformity across services:
   - Use namespaces to properly identify the subject, action, object, and context. For example, use ``org:123`` to refer to a specific org with ID 123. The exceptions for this rule are the objects that already have a namespace like ``course-v1:OpenedX+DemoX+DemoCourse`` or ``lib:DemoX:CSPROB``.
@@ -44,20 +40,26 @@ Use a simplicity and clarity-first approach to Policy Definitions
 - Use custom matchers to implement complex logic, but keep them as simple and reusable as possible.
 - Document all default policies with in-line comments in the ``authz.policy`` files to explain their purpose and usage.
 
-Roles are scoped to a specific context in the policy
-----------------------------------------------------
-- Grouping resources will not be implemented via Casbin's built-in role hierarchies (g, g2) but will be explicitly managed when checking permissions in the application layer. For example, if a user has the ``course_admin`` role in ``org:123``, this will not automatically grant them the ``course_admin`` role in all courses within that org. Instead, the application layer will need to check both the user's role and the specific context (e.g., organization or course) when making authorization decisions.
-- Define roles that are context-specific, such as ``course_admin`` for a specific course or ``org_admin`` for a specific organization.
+Use ``authz.policy`` Files for Default Policies
+-----------------------------------------------
+- Each service will ship with an ``authz.policy`` file that defines its default policies which are immutable after load. These provide a baseline set of policies that ensure consistent behavior across deployments.
+- The ``authz.policy`` file will be loaded by the Open edX Layer at service initialization and saved in the policy store upon first load. They provide a baseline set of policies that ensure consistent behavior across deployments.
+- Default policies should be subjected to load-testing to ensure they do not introduce performance regressions.
+- Services can override the default ``authz.policy`` file by providing a custom file path via configuration if needed.
 
 #. Policy Management and Versioning
 ====================================
 
+Store Dynamic Policies Directly in the Policy Store
+---------------------------------------------------
+- Consider two types of policies: static policies (shipped with services in ``authz.policy`` files) and dynamic policies (created and managed via the Policy Management API and persisted in the policy store).
+- Dynamic policies created via the Policy Management API will be stored directly in the policy store (MySQL database) using a Casbin adapter.
+
 Differentiate Between Static and Dynamic Policies
 -------------------------------------------------
-- Consider two types of policies: static policies (shipped with services in ``authz.policy`` files) and dynamic policies (created and managed via the Policy Management API and persisted in the policy store).
+- Static policies (default) should be differentiated from dynamic policies in the policy store using a metadata field (e.g., ``is_static`` boolean field) and should be immutable after being loaded from the ``authz.policy`` file.
 - Dynamic policies can be created, updated, and deleted via the Policy Management API, allowing administrators to adapt policies to changing requirements without modifying service code.
 - Using dynamic policies allows for greater flexibility and adaptability, as policies can be modified in response to evolving business needs or security requirements. However, they might also introduce complexity and potential performance overhead if not defined and managed carefully.
-- Maintain a clear separation between static policies (shipped with services) and dynamic policies (managed via the policy data store).
 
 Version Static Policies and Make Dynamic Policies Immutable
 -----------------------------------------------------------
@@ -65,31 +67,47 @@ Version Static Policies and Make Dynamic Policies Immutable
 - Dynamic policies created via the Policy Management API should be immutable once created. To change a dynamic policy, it should be deleted and recreated with the desired changes. This approach ensures that policy changes are auditable and traceable.
 - Implement auditing and logging for all policy changes, including who made the change, when it was made, and what the change was. This is crucial for maintaining security and compliance.
 
-#. Authorization Source of Truth and Clients Boundaries
-=======================================================
+#. Authorization Source of Truth
+=================================
 
 Make the Policy Store the Single Source of Truth
 ------------------------------------------------
-- The ``model.conf`` with the Casbin model configuration and the policy store (via MySQL adapter) together form the single source of truth for authorization in Open edX.
-- The policy store contains all dynamic policies and the static policies loaded from the ``authz.policy`` files at service initialization. The policy origin (static vs dynamic) can be tracked via metadata fields if needed.
+- The ``model.conf`` with the Casbin model configuration (``model.conf``) and the policy store (via MySQL adapter) together form the single source of truth for authorization in Open edX.
+- The policy store contains all dynamic policies and the static policies loaded from the ``authz.policy`` files at service initialization.
 - The policy store is the single source of truth for authorization rules. By default, services share the same store to ensure consistency and avoid conflicts.
-
-Delegate Policy Ownership to Services
--------------------------------------
-- Services are responsible for defining their own policies in the ``authz.policy`` files and managing their own dynamic policies via the Policy Management API.
-- These policies are managed by each service according to its domain. For example, the LMS manages courseware access policies, while the CMS manages content creation policies.
-- Authorization decisions must always be answered by the service that owns the relevant data and policies (policy owner). For instance, the LMS decides whether a user can access a course because it owns enrollments and courseware data. The CMS decides whether a user can edit content because it owns the content data.
-
-Enforce Consistency via the Open edX Layer
-------------------------------------------
-- Services do not maintain their own copies of policies or implement their own authorization logic. All authorization decisions are made by the Open edX Layer based on the policies in the policy store.
 
 Allow Shared or Separate Policy Stores as Needed
 ------------------------------------------------
 - By default, all services share the same policy store to ensure consistency and avoid conflicts.
 - If isolation between services is required, this can be achieved in two ways: (1) by using a namespace or domain field in the shared table, or (2) by creating a separate policy store for a specific service.
 
+#. Authorization Ownership
+===========================
+
+Delegate Policy Ownership to Services
+-------------------------------------
+- Services are responsible for defining their own policies in the ``authz.policy`` files and managing their own dynamic policies via the Policy Management API.
+- These policies are managed by each service according to its domain. For example, the LMS manages courseware access policies, while the CMS manages content creation policies.
+- Authorization decisions must always be answered by the service that owns the relevant data and policies (policy owner). For instance, the LMS decides whether a user can access a course because it owns enrollments and courseware data. The CMS decides whether a user can edit content because it owns the content data.
+- The policy store is by default shared across services, but each service is responsible for its own policies and authorization decisions.
+
 Consequences
 ************
 
+#. **Define RBAC in the Casbin Model (``model.conf``)**: The Casbin model configuration (``model.conf``) will define the RBAC structure, including roles, permissions, and the relationships between them. This ensures that the authorization engine can correctly interpret and enforce the defined policies.
+
+#. **ABAC will be Supported Eventually via Custom Matchers**: While the initial implementation will focus on RBAC, the Casbin model will be designed to support ABAC features in the future. This will be achieved through the use of custom matchers that can evaluate attributes of subjects, actions, objects, and contexts.
+
+#. **Default Deny Policy**: The default behavior of the authorization engine will be to deny access unless explicitly allowed by a policy. This is a security best practice that minimizes the risk of unauthorized access.
+
+#. **Grouping will be Handled in the Application Layer**: Instead of using Casbin's built-in grouping mechanisms, the application layer will handle grouping and context inheritance. This provides greater flexibility and allows for more complex authorization logic that is specific to the application's needs.
+
+#. **The Casbin Table Schema will Include Metadata**: The policy store schema will include metadata fields to differentiate between static and dynamic policies. This allows for better management and auditing of policies.
+
+#. **Static Policies will be Immutable**: Policies defined in the ``authz.policy`` files will be immutable after being loaded into the policy store. For a policy to be removed, should go through a deprecation cycle where it is first marked as deprecated and then removed in a future version.
+
+#. **Each Service Should Define Its Own Policies (``authz.policy``)**: Each service is responsible for defining its own policies in the ``authz.policy`` files and managing its own dynamic policies via the Policy Management API. This ensures that services can tailor their authorization rules to their specific needs while maintaining a clear boundary of responsibility. If no defaults are defined, the service will start with an empty policy set.
+
 #. **Clients Share the Same Policy Store**: By default, all services share the same policy store to ensure consistency and avoid conflicts. This means that policies defined by one service can affect authorization decisions in another service.
+
+#. **Making Policies Immutable Might Introduce Operational Complexity**: While making dynamic policies immutable after creation enhances security and auditability, it may introduce operational complexity. Administrators will need to delete and recreate policies to make changes, which could lead to increased administrative overhead.

--- a/docs/decisions/0007-consistency-and-policy-lifecycle.rst
+++ b/docs/decisions/0007-consistency-and-policy-lifecycle.rst
@@ -1,0 +1,2 @@
+Use Cache to Optimize Data Access
+---------------------------------


### PR DESCRIPTION
## Description
ADR for policy and model (all casbin-related concepts) management fit to our environment. In this ADR we make decisions for:
- The authorization engine configuration (model.conf) which tells the system how to behave
- Magement of authz.policy and the policy store
- Make the policy store the source of truth for authorization

**Merge checklist:**
Check off if complete *or* not applicable:
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Fixup commits are squashed away
- [ ] Unit tests added/updated
- [ ] Manual testing instructions provided
- [ ] Noted any: Concerns, dependencies, migration issues, deadlines, tickets
