### PR TITLE
[FC-0099] docs: add ADR proposing how to manage the policy store

### DIFF
--- a/docs/decisions/0002-authorization-model-foundation.rst
+++ b/docs/decisions/0002-authorization-model-foundation.rst
@@ -189,20 +189,6 @@ References
 Glossary
 ********
 
-* **Action**: The operation attempted on a resource (e.g., view, edit, delete).
-* **Attribute**: Property of a user or resource used in ABAC (e.g., user.profile.department == course.org).
-* **Authorization check**: The explicit way a service asks whether an operation is allowed, always expressed in S-A-O-C form.
-* **Authorization models**: Frameworks or approaches that define how to express who can do what, on which resource, and under which conditions. Common models include RBAC, ABAC, and ReBAC.
-
-  * **RBAC (Role-Based Access Control)**: Authorization model where access is granted based on roles assigned to users.
-  * **Scoped RBAC**: A variant of RBAC where roles apply within a specific scope (e.g., organization, course, library).
-  * **ABAC (Attribute-Based Access Control)**: Authorization model where access is granted based on attributes of the subject, object, and context (e.g., user's organization, resource type, time of day).
-  * **ReBAC (Relationship-Based Access Control)**: Authorization model where access decisions are based on explicit relationships between subjects and objects, often modeled as a graph.
-
-* **Permission**: Atomic unit of access (e.g., ``CREATE_COURSE``, ``EDIT_ROLE``).
-* **Policy**: A declarative rule that defines which subjects can perform which actions on which objects under which context. Policies are stored outside of code, versioned, and auditable.
-* **Relationship**: Link between entities granting access in ReBAC (e.g., user:alice#editor@course:math101).
-* **Resource**: The object being accessed (e.g., Course).
-* **Role**: A collection of permissions assigned to a user (e.g., Instructor).
-* **S-A-O-C (Subject-Action-Object-Context)**: The canonical shape of any authorization check: *is Subject allowed to perform Action on Object under Context?*
-* **Scope**: The boundary where a role applies (e.g., Instructor in Course A, Admin in Org B).
+See the :doc:`central glossary </references/glossary>` for definitions of all terms used across
+these ADRs, including :term:`Action`, :term:`Policy`, :term:`Role`, :term:`Scope`,
+:term:`S-A-O-C`, :term:`RBAC`, :term:`ABAC`, and :term:`ReBAC`.

--- a/docs/decisions/0005-architecture-and-data-modeling.rst
+++ b/docs/decisions/0005-architecture-and-data-modeling.rst
@@ -32,7 +32,7 @@ The architecture consists of several key components:
 - **Policy Store**: The database (via Django ORM) where all authorization policies are persisted. The policy store holds two categories of policies:
 
   1. **Static policies**: Default role-permission definitions (e.g., the built-in permissions for ``library_admin`` or ``course_staff``) and action groupings. These are defined in the ``authz.policy`` file shipped with the package, and loaded into the policy store via the ``load_policies`` management command at deployment time. They are not meant to be edited by operators. A parallel Python representation exists in ``openedx_authz.constants`` (``roles.py``, ``permissions.py``) for use in code (e.g., migration scripts, API views).
-  2. **Dynamic policies**: Created at runtime through the Policy Management API or Django Admin. These include role assignments (granting a user a role in a scope) and any operator-defined policy additions.
+  2. **Dynamic policies**: Created at runtime through the Role Management API or Django Admin. These include role assignments (granting a user a role in a scope) and any operator-defined policy additions.
 
   Both categories are stored in the same ``CasbinRule`` table and are loaded into the engine uniformly. The distinction is organizational, not structural.
 
@@ -73,7 +73,7 @@ A Dedicated Open edX Layer for Authorization
 ---------------------------------------------
 - Implement an Open edX-specific layer that encapsulates all authorization logic by interacting with the Authorization Engine, ensuring that services interact with a consistent interface.
 - The Open edX Layer provides a stable Enforcement API that abstracts Casbin internals, allowing services to request authorization decisions without needing to understand Casbin specifics.
-- Implement a Policy Management API within the Open edX Layer to allow administrators to manage and update authorization policies centrally.
+- Implement a Role Management API within the Open edX Layer to allow administrators to manage and update authorization policies centrally.
 - The Open edX Layer is implemented as a Django app (``openedx_authz``) installable as a pip dependency. It registers as both an LMS and CMS plugin via ``entry_points`` for automatic discovery. It may also serve as a shared library for other services.
 - All modifications to the Authorization Engine configuration (model, adapters, etc.) are done through the Open edX Layer, so no forks of Casbin are needed.
 
@@ -236,7 +236,7 @@ Consequences
 #. **New Components in the Open edX Ecosystem**: There are several new components introduced as part of this architecture:
    - Policy Store: The database tables (``CasbinRule``, ``ExtendedCasbinRule``, ``PolicyCacheControl``, ``Scope`` subclasses, ``Subject`` subclasses) managed through the Django ORM.
    - Enforcement API: The Public Python API and REST API for enforcing authorization policies and making authorization decisions.
-   - Policy Management API: Functions for creating, updating, and deleting dynamic policies in the Policy Store.
+   - Role Management API: Functions for creating, updating, and deleting dynamic policies in the Policy Store.
    - Open edX Layer: The ``openedx_authz`` Django app that abstracts access to the Policy Store and provides a unified interface for authorization.
    - Authorization Engine: The Casbin-based ``AuthzEnforcer`` singleton that evaluates authorization requests based on defined policies.
 
@@ -271,6 +271,7 @@ Consequences
 References
 **********
 
+- :doc:`/references/glossary` — definitions of :term:`Authorization Engine`, :term:`Policy Store`, :term:`Enforcement API`, :term:`Open edX Layer`, :term:`Static Policy`, :term:`Dynamic Policy`, :term:`Scope`, :term:`Subject`, and other terms used in this ADR.
 - `Authorization Model Foundations ADR`_
 - `Technology Selection ADR`_
 - `ADR 0007`_

--- a/docs/decisions/0006-policy-store-and-enforcement-model.rst
+++ b/docs/decisions/0006-policy-store-and-enforcement-model.rst
@@ -90,6 +90,23 @@ Delegate Policy Ownership to Services
 - Authorization decisions must always be answered by the service that owns the relevant data and policies (policy owner). For instance, the LMS decides whether a user can access a course because it owns enrollments and courseware data. The CMS decides whether a user can edit content because it owns the content data.
 - The policy store is by default shared across services, but each service is responsible for its own policies and authorization decisions.
 
+#. Policy Lifecycle
+===================
+
+Use a Back-reference Model to Track Domain Objects
+--------------------------------------------------
+- Use an intermediate back-reference model to track domain objects (e.g., courses, organizations) and their relationships to users and roles.
+- Use cascading deletes to ensure that when a domain object is deleted, all associated policies are also removed from the policy store. This helps maintain data integrity and prevents orphaned policies.
+
+Use a Periodic Reconciliation Process to Clean Up Stale Policies
+----------------------------------------------------------------
+- Implement periodic cleanup tasks to remove stale or orphaned policies that may not be automatically deleted due to unforeseen circumstances.
+- This reconciliation process will help maintain the integrity of the policy store and ensure that it reflects the current state of the system.
+
+Create the Record of the Back-reference Model in the same Transaction as the Policy Creation
+--------------------------------------------------------------------------------------------
+- To ensure data integrity, the creation of the back-reference model record and the corresponding policy in the policy store should occur within the same transaction. This ensures that both operations succeed or fail together.
+
 Consequences
 ************
 
@@ -110,3 +127,7 @@ Consequences
 #. **Clients Share the Same Policy Store**: By default, all services share the same policy store to ensure consistency and avoid conflicts. This means that policies defined by one service can affect authorization decisions in another service.
 
 #. **Making Policies Immutable Might Introduce Operational Complexity**: While making dynamic policies immutable after creation enhances security and auditability, it may introduce operational complexity. Administrators will need to delete and recreate policies to make changes, which could lead to increased administrative overhead.
+
+#. **Performance Considerations**: The use of dynamic policies and complex matchers may introduce performance overhead. It is essential to monitor the performance of the authorization engine and optimize policies and matchers as needed to ensure that authorization checks remain efficient.
+
+#. **For Data Integrity Purposes, Place the Policy Store Where the Data is Owned**: To ensure data integrity and consistency, the policy store should be hosted in the same environment as the services that own the data and policies. If this is not feasible, additional mechanisms must be implemented to maintain consistency like an event-bus mechanism.

--- a/docs/decisions/0006-policy-store-and-enforcement-model.rst
+++ b/docs/decisions/0006-policy-store-and-enforcement-model.rst
@@ -1,0 +1,95 @@
+0005: Policy Store and Casbin Configuration Model
+#################################################
+
+Status
+******
+**Draft**
+
+Context
+*******
+
+This ADR details how authorization policies are stored, versioned, and configured across the platform. It defines the Policy Store as the single source of truth, describes the relational database schema and metadata, and establishes naming conventions for subjects, actions, objects, and contexts. It also specifies the Casbin ``model.conf`` configuration, including the default matcher, allow/deny effects, static vs. dynamic policies, versioning rules, and how services ship and manage their ``authz.policy`` files.
+
+Decision
+********
+
+#. Authorization Engine Configuration
+=====================================
+
+Use a Casbin Model CONF that Supports Core Principles
+-----------------------------------------------------
+- Use a Casbin configuration model (``model.conf``) that supports Subject-Action-Object-Context checks, explicit scopes, and both RBAC and ABAC features.
+- Start supporting RBAC with roles and permissions, and evolve towards ABAC as needed to enable more granular and context-aware policies.
+- The ``model.conf`` file will be shared across all services unless explicitly overridden for a specific service.
+- The model configuration will be versioned and managed as part of the Open edX ecosystem to ensure consistency and traceability.
+- Favor simple matchers to improve performance and maintainability. This means avoiding complex regexes and nested logic where possible.
+- Explicitly define the effects of policies (allow/deny) and ensure that the default behavior is to deny unless explicitly allowed.
+- Use Casbin's built-in support for role hierarchies (g, g2) to manage role inheritance and simplify policy definitions.
+
+Use ``authz.policy`` Files for Default Policies
+-----------------------------------------------
+- Each service will ship with an ``authz.policy`` file that defines its default policies.
+- The ``authz.policy`` file will be loaded by the Open edX Layer at service initialization and saved in the policy store upon first load. They provide a baseline set of policies that ensure consistent behavior across deployments.
+- Default policies are immutable after load and provide a baseline set of policies that ensure consistent behavior across deployments.
+- Default policies should be subjected to load-testing to ensure they do not introduce performance regressions.
+
+Use a simplicity and clarity-first approach to Policy Definitions
+-----------------------------------------------------------------
+- Favor the use of simple and easy to read matchers and policies to keep the system maintainable. Revisit complexity if needed.
+- Define clear and consistent naming conventions for subjects, actions, objects, and contexts to ensure uniformity across services:
+  - Use namespaces to properly identify the subject, action, object, and context. For example, use ``org:123`` to refer to a specific org with ID 123. The exceptions for this rule are the objects that already have a namespace like ``course-v1:OpenedX+DemoX+DemoCourse`` or ``lib:DemoX:CSPROB``.
+  - Use singular verbs for actions (e.g., ``view``, ``edit``, ``delete``) with snake_case formatting when multiple words are needed (e.g., ``view_grades``, ``edit_content``).
+  - Use the username as the subject when referring to individual users (e.g., ``alice``, ``bob``).
+  - Use clear and descriptive names for roles. (e.g., ``course_admin``, ``content_creator``).
+- Use custom matchers to implement complex logic, but keep them as simple and reusable as possible.
+- Document all default policies with in-line comments in the ``authz.policy`` files to explain their purpose and usage.
+
+Roles are scoped to a specific context in the policy
+----------------------------------------------------
+- Grouping resources will not be implemented via Casbin's built-in role hierarchies (g, g2) but will be explicitly managed when checking permissions in the application layer. For example, if a user has the ``course_admin`` role in ``org:123``, this will not automatically grant them the ``course_admin`` role in all courses within that org. Instead, the application layer will need to check both the user's role and the specific context (e.g., organization or course) when making authorization decisions.
+- Define roles that are context-specific, such as ``course_admin`` for a specific course or ``org_admin`` for a specific organization.
+
+#. Policy Management and Versioning
+====================================
+
+Differentiate Between Static and Dynamic Policies
+-------------------------------------------------
+- Consider two types of policies: static policies (shipped with services in ``authz.policy`` files) and dynamic policies (created and managed via the Policy Management API and persisted in the policy store).
+- Dynamic policies can be created, updated, and deleted via the Policy Management API, allowing administrators to adapt policies to changing requirements without modifying service code.
+- Using dynamic policies allows for greater flexibility and adaptability, as policies can be modified in response to evolving business needs or security requirements. However, they might also introduce complexity and potential performance overhead if not defined and managed carefully.
+- Maintain a clear separation between static policies (shipped with services) and dynamic policies (managed via the policy data store).
+
+Version Static Policies and Make Dynamic Policies Immutable
+-----------------------------------------------------------
+- Version the ``authz.policy`` files with the service version to ensure that changes to static policies are tracked and can be rolled back if needed.
+- Dynamic policies created via the Policy Management API should be immutable once created. To change a dynamic policy, it should be deleted and recreated with the desired changes. This approach ensures that policy changes are auditable and traceable.
+- Implement auditing and logging for all policy changes, including who made the change, when it was made, and what the change was. This is crucial for maintaining security and compliance.
+
+#. Authorization Source of Truth and Clients Boundaries
+=======================================================
+
+Make the Policy Store the Single Source of Truth
+------------------------------------------------
+- The ``model.conf`` with the Casbin model configuration and the policy store (via MySQL adapter) together form the single source of truth for authorization in Open edX.
+- The policy store contains all dynamic policies and the static policies loaded from the ``authz.policy`` files at service initialization. The policy origin (static vs dynamic) can be tracked via metadata fields if needed.
+- The policy store is the single source of truth for authorization rules. By default, services share the same store to ensure consistency and avoid conflicts.
+
+Delegate Policy Ownership to Services
+-------------------------------------
+- Services are responsible for defining their own policies in the ``authz.policy`` files and managing their own dynamic policies via the Policy Management API.
+- These policies are managed by each service according to its domain. For example, the LMS manages courseware access policies, while the CMS manages content creation policies.
+- Authorization decisions must always be answered by the service that owns the relevant data and policies (policy owner). For instance, the LMS decides whether a user can access a course because it owns enrollments and courseware data. The CMS decides whether a user can edit content because it owns the content data.
+
+Enforce Consistency via the Open edX Layer
+------------------------------------------
+- Services do not maintain their own copies of policies or implement their own authorization logic. All authorization decisions are made by the Open edX Layer based on the policies in the policy store.
+
+Allow Shared or Separate Policy Stores as Needed
+------------------------------------------------
+- By default, all services share the same policy store to ensure consistency and avoid conflicts.
+- If isolation between services is required, this can be achieved in two ways: (1) by using a namespace or domain field in the shared table, or (2) by creating a separate policy store for a specific service.
+
+Consequences
+************
+
+#. **Clients Share the Same Policy Store**: By default, all services share the same policy store to ensure consistency and avoid conflicts. This means that policies defined by one service can affect authorization decisions in another service.

--- a/docs/decisions/0006-policy-store-and-enforcement-model.rst
+++ b/docs/decisions/0006-policy-store-and-enforcement-model.rst
@@ -37,8 +37,6 @@ Establish Naming Conventions for Subjects, Actions, Objects, and Contexts
   - Use singular verbs for actions (e.g., ``view``, ``edit``, ``delete``) with snake_case formatting when multiple words are needed (e.g., ``view_grades``, ``edit_content``).
   - Use the username as the subject when referring to individual users (e.g., ``alice``, ``bob``).
   - Use clear and descriptive names for roles. (e.g., ``course_admin``, ``content_creator``).
-- Use custom matchers to implement complex logic, but keep them as simple and reusable as possible.
-- Document all default policies with in-line comments in the ``authz.policy`` files to explain their purpose and usage.
 
 Use ``authz.policy`` Files for Default Policies
 -----------------------------------------------
@@ -46,6 +44,7 @@ Use ``authz.policy`` Files for Default Policies
 - The ``authz.policy`` file will be loaded by the Open edX Layer at service initialization and saved in the policy store upon first load. They provide a baseline set of policies that ensure consistent behavior across deployments.
 - Default policies should be subjected to load-testing to ensure they do not introduce performance regressions.
 - Services can override the default ``authz.policy`` file by providing a custom file path via configuration if needed.
+- Document all default policies with in-line comments in the ``authz.policy`` files to explain their purpose and usage.
 
 #. Policy Management and Versioning
 ====================================

--- a/docs/decisions/0006-policy-store-and-enforcement-model.rst
+++ b/docs/decisions/0006-policy-store-and-enforcement-model.rst
@@ -13,28 +13,24 @@ This ADR details how authorization policies are stored, versioned, and configure
 Decision
 ********
 
-#. Authorization Engine Configuration
-=====================================
+#. Authorization Engine Configuration (``model.conf`` & ``authz.policy``)
+=========================================================================
 
 Use a Casbin Model CONF that Supports Core Principles
 -----------------------------------------------------
 - Use a Casbin configuration model (``model.conf``) that supports Subject-Action-Object-Context checks, explicit scopes, and both RBAC and ABAC features.
-- Start supporting RBAC with roles and permissions, and evolve towards ABAC as needed to enable more granular and context-aware policies.
 - The ``model.conf`` file will be shared across all services unless explicitly overridden for a specific service.
-- The model configuration will be versioned and managed as part of the Open edX ecosystem to ensure consistency and traceability.
-- Favor simple matchers to improve performance and maintainability. This means avoiding complex regexes and nested logic where possible.
 - Explicitly define the effects of policies (allow/deny) and ensure that the default behavior is to deny unless explicitly allowed.
+- Favor simple matchers to improve performance and maintainability. This means avoiding complex regexes and nested logic where possible.
 - Use Casbin's built-in support for role hierarchies (g, g2) to manage role inheritance and simplify policy definitions.
 
-Use ``authz.policy`` Files for Default Policies
------------------------------------------------
-- Each service will ship with an ``authz.policy`` file that defines its default policies.
-- The ``authz.policy`` file will be loaded by the Open edX Layer at service initialization and saved in the policy store upon first load. They provide a baseline set of policies that ensure consistent behavior across deployments.
-- Default policies are immutable after load and provide a baseline set of policies that ensure consistent behavior across deployments.
-- Default policies should be subjected to load-testing to ensure they do not introduce performance regressions.
+Do not Handle Grouping and Context Inheritance via Casbin's Built-in Mechanisms
+-------------------------------------------------------------------------------
+- Grouping resources will not be implemented via Casbin's built-in grouping mechanisms (g, g2) but will be explicitly managed when checking permissions in the application layer. For example, if a user has the ``course_admin`` role in ``org:123``, this will not automatically grant them the ``course_admin`` role in all courses within that org. Instead, the application layer will need to check both the user's role and the specific context (e.g., organization or course) when making authorization decisions.
+- Define roles that are context-specific, such as ``course_admin`` for a specific course or ``org_admin`` for a specific organization.
 
-Use a simplicity and clarity-first approach to Policy Definitions
------------------------------------------------------------------
+Establish Naming Conventions for Subjects, Actions, Objects, and Contexts
+-------------------------------------------------------------------------
 - Favor the use of simple and easy to read matchers and policies to keep the system maintainable. Revisit complexity if needed.
 - Define clear and consistent naming conventions for subjects, actions, objects, and contexts to ensure uniformity across services:
   - Use namespaces to properly identify the subject, action, object, and context. For example, use ``org:123`` to refer to a specific org with ID 123. The exceptions for this rule are the objects that already have a namespace like ``course-v1:OpenedX+DemoX+DemoCourse`` or ``lib:DemoX:CSPROB``.
@@ -44,20 +40,26 @@ Use a simplicity and clarity-first approach to Policy Definitions
 - Use custom matchers to implement complex logic, but keep them as simple and reusable as possible.
 - Document all default policies with in-line comments in the ``authz.policy`` files to explain their purpose and usage.
 
-Roles are scoped to a specific context in the policy
-----------------------------------------------------
-- Grouping resources will not be implemented via Casbin's built-in role hierarchies (g, g2) but will be explicitly managed when checking permissions in the application layer. For example, if a user has the ``course_admin`` role in ``org:123``, this will not automatically grant them the ``course_admin`` role in all courses within that org. Instead, the application layer will need to check both the user's role and the specific context (e.g., organization or course) when making authorization decisions.
-- Define roles that are context-specific, such as ``course_admin`` for a specific course or ``org_admin`` for a specific organization.
+Use ``authz.policy`` Files for Default Policies
+-----------------------------------------------
+- Each service will ship with an ``authz.policy`` file that defines its default policies which are immutable after load. These provide a baseline set of policies that ensure consistent behavior across deployments.
+- The ``authz.policy`` file will be loaded by the Open edX Layer at service initialization and saved in the policy store upon first load. They provide a baseline set of policies that ensure consistent behavior across deployments.
+- Default policies should be subjected to load-testing to ensure they do not introduce performance regressions.
+- Services can override the default ``authz.policy`` file by providing a custom file path via configuration if needed.
 
 #. Policy Management and Versioning
 ====================================
 
+Store Dynamic Policies Directly in the Policy Store
+---------------------------------------------------
+- Consider two types of policies: static policies (shipped with services in ``authz.policy`` files) and dynamic policies (created and managed via the Policy Management API and persisted in the policy store).
+- Dynamic policies created via the Policy Management API will be stored directly in the policy store (MySQL database) using a Casbin adapter.
+
 Differentiate Between Static and Dynamic Policies
 -------------------------------------------------
-- Consider two types of policies: static policies (shipped with services in ``authz.policy`` files) and dynamic policies (created and managed via the Policy Management API and persisted in the policy store).
+- Static policies (default) should be differentiated from dynamic policies in the policy store using a metadata field (e.g., ``is_static`` boolean field) and should be immutable after being loaded from the ``authz.policy`` file.
 - Dynamic policies can be created, updated, and deleted via the Policy Management API, allowing administrators to adapt policies to changing requirements without modifying service code.
 - Using dynamic policies allows for greater flexibility and adaptability, as policies can be modified in response to evolving business needs or security requirements. However, they might also introduce complexity and potential performance overhead if not defined and managed carefully.
-- Maintain a clear separation between static policies (shipped with services) and dynamic policies (managed via the policy data store).
 
 Version Static Policies and Make Dynamic Policies Immutable
 -----------------------------------------------------------
@@ -65,31 +67,47 @@ Version Static Policies and Make Dynamic Policies Immutable
 - Dynamic policies created via the Policy Management API should be immutable once created. To change a dynamic policy, it should be deleted and recreated with the desired changes. This approach ensures that policy changes are auditable and traceable.
 - Implement auditing and logging for all policy changes, including who made the change, when it was made, and what the change was. This is crucial for maintaining security and compliance.
 
-#. Authorization Source of Truth and Clients Boundaries
-=======================================================
+#. Authorization Source of Truth
+=================================
 
 Make the Policy Store the Single Source of Truth
 ------------------------------------------------
-- The ``model.conf`` with the Casbin model configuration and the policy store (via MySQL adapter) together form the single source of truth for authorization in Open edX.
-- The policy store contains all dynamic policies and the static policies loaded from the ``authz.policy`` files at service initialization. The policy origin (static vs dynamic) can be tracked via metadata fields if needed.
+- The ``model.conf`` with the Casbin model configuration (``model.conf``) and the policy store (via MySQL adapter) together form the single source of truth for authorization in Open edX.
+- The policy store contains all dynamic policies and the static policies loaded from the ``authz.policy`` files at service initialization.
 - The policy store is the single source of truth for authorization rules. By default, services share the same store to ensure consistency and avoid conflicts.
-
-Delegate Policy Ownership to Services
--------------------------------------
-- Services are responsible for defining their own policies in the ``authz.policy`` files and managing their own dynamic policies via the Policy Management API.
-- These policies are managed by each service according to its domain. For example, the LMS manages courseware access policies, while the CMS manages content creation policies.
-- Authorization decisions must always be answered by the service that owns the relevant data and policies (policy owner). For instance, the LMS decides whether a user can access a course because it owns enrollments and courseware data. The CMS decides whether a user can edit content because it owns the content data.
-
-Enforce Consistency via the Open edX Layer
-------------------------------------------
-- Services do not maintain their own copies of policies or implement their own authorization logic. All authorization decisions are made by the Open edX Layer based on the policies in the policy store.
 
 Allow Shared or Separate Policy Stores as Needed
 ------------------------------------------------
 - By default, all services share the same policy store to ensure consistency and avoid conflicts.
 - If isolation between services is required, this can be achieved in two ways: (1) by using a namespace or domain field in the shared table, or (2) by creating a separate policy store for a specific service.
 
+#. Authorization Ownership
+===========================
+
+Delegate Policy Ownership to Services
+-------------------------------------
+- Services are responsible for defining their own policies in the ``authz.policy`` files and managing their own dynamic policies via the Policy Management API.
+- These policies are managed by each service according to its domain. For example, the LMS manages courseware access policies, while the CMS manages content creation policies.
+- Authorization decisions must always be answered by the service that owns the relevant data and policies (policy owner). For instance, the LMS decides whether a user can access a course because it owns enrollments and courseware data. The CMS decides whether a user can edit content because it owns the content data.
+- The policy store is by default shared across services, but each service is responsible for its own policies and authorization decisions.
+
 Consequences
 ************
 
+#. **Define RBAC in the Casbin Model (``model.conf``)**: The Casbin model configuration (``model.conf``) will define the RBAC structure, including roles, permissions, and the relationships between them. This ensures that the authorization engine can correctly interpret and enforce the defined policies.
+
+#. **ABAC will be Supported Eventually via Custom Matchers**: While the initial implementation will focus on RBAC, the Casbin model will be designed to support ABAC features in the future. This will be achieved through the use of custom matchers that can evaluate attributes of subjects, actions, objects, and contexts.
+
+#. **Default Deny Policy**: The default behavior of the authorization engine will be to deny access unless explicitly allowed by a policy. This is a security best practice that minimizes the risk of unauthorized access.
+
+#. **Grouping will be Handled in the Application Layer**: Instead of using Casbin's built-in grouping mechanisms, the application layer will handle grouping and context inheritance. This provides greater flexibility and allows for more complex authorization logic that is specific to the application's needs.
+
+#. **The Casbin Table Schema will Include Metadata**: The policy store schema will include metadata fields to differentiate between static and dynamic policies. This allows for better management and auditing of policies.
+
+#. **Static Policies will be Immutable**: Policies defined in the ``authz.policy`` files will be immutable after being loaded into the policy store. For a policy to be removed, should go through a deprecation cycle where it is first marked as deprecated and then removed in a future version.
+
+#. **Each Service Should Define Its Own Policies (``authz.policy``)**: Each service is responsible for defining its own policies in the ``authz.policy`` files and managing its own dynamic policies via the Policy Management API. This ensures that services can tailor their authorization rules to their specific needs while maintaining a clear boundary of responsibility. If no defaults are defined, the service will start with an empty policy set.
+
 #. **Clients Share the Same Policy Store**: By default, all services share the same policy store to ensure consistency and avoid conflicts. This means that policies defined by one service can affect authorization decisions in another service.
+
+#. **Making Policies Immutable Might Introduce Operational Complexity**: While making dynamic policies immutable after creation enhances security and auditability, it may introduce operational complexity. Administrators will need to delete and recreate policies to make changes, which could lead to increased administrative overhead.

--- a/docs/decisions/0006-policy-store-and-enforcement-model.rst
+++ b/docs/decisions/0006-policy-store-and-enforcement-model.rst
@@ -8,7 +8,9 @@ Status
 Context
 *******
 
-This ADR details how authorization policies are stored, versioned, and configured across the platform. It defines the Policy Store as the single source of truth, describes the relational database schema and metadata, and establishes naming conventions for subjects, actions, objects, and contexts. It also specifies the Casbin ``model.conf`` configuration, including the default matcher, allow/deny effects, static vs. dynamic policies, versioning rules, and how services ship and manage their ``authz.policy`` files.
+This ADR details how authorization policies are stored, versioned, and configured across the platform. It defines the :term:`Policy Store` as the single source of truth, describes the relational database schema and metadata, and establishes naming conventions for :term:`subjects<Subject>`, :term:`actions<Action>`, objects, and contexts. It also specifies the Casbin :term:`model configuration<Model Configuration>` (``model.conf``), including the default :term:`matcher<Matcher>`, allow/deny effects, :term:`static<Static Policy>` vs. :term:`dynamic policies<Dynamic Policy>`, versioning rules, and how services ship and manage their ``authz.policy`` files.
+
+.. seealso:: :doc:`/references/glossary` for definitions of all terms used in this ADR.
 
 Decision
 ********
@@ -49,21 +51,21 @@ Use ``authz.policy`` Files for Default Policies
 #. Policy Management and Versioning
 ====================================
 
-Store Dynamic Policies Directly in the Policy Store
----------------------------------------------------
-- Consider two types of policies: static policies (shipped with services in ``authz.policy`` files) and dynamic policies (created and managed via the Policy Management API and persisted in the policy store).
-- Dynamic policies created via the Policy Management API will be stored directly in the policy store (MySQL database) using a Casbin adapter.
+Store Dynamic Policies Directly in the Policy Store (Django ORM Adapter)
+------------------------------------------------------------------------
+- Consider two types of policies: static policies (shipped with services in ``authz.policy`` files) and dynamic policies (created and managed via the Role Management API and persisted in the policy store).
+- Dynamic policies created via the Role Management API will be stored directly in the policy store (MySQL database) using a Casbin adapter.
 
 Differentiate Between Static and Dynamic Policies
 -------------------------------------------------
 - Static policies (default) should be differentiated from dynamic policies in the policy store using a metadata field (e.g., ``is_static`` boolean field) and should be immutable after being loaded from the ``authz.policy`` file.
-- Dynamic policies can be created, updated, and deleted via the Policy Management API, allowing administrators to adapt policies to changing requirements without modifying service code.
+- Dynamic policies can be created, updated, and deleted via the Role Management API, allowing administrators to adapt policies to changing requirements without modifying service code.
 - Using dynamic policies allows for greater flexibility and adaptability, as policies can be modified in response to evolving business needs or security requirements. However, they might also introduce complexity and potential performance overhead if not defined and managed carefully.
 
 Version Static Policies and Make Dynamic Policies Immutable
 -----------------------------------------------------------
-- Version the ``authz.policy`` files with the service version to ensure that changes to static policies are tracked and can be rolled back if needed.
-- Dynamic policies created via the Policy Management API should be immutable once created. To change a dynamic policy, it should be deleted and recreated with the desired changes. This approach ensures that policy changes are auditable and traceable.
+- Version the ``authz.policy`` files with the along with the framework version to ensure that changes to static policies are tracked and can be rolled back if needed.
+- Dynamic policies created via the Role Management API should be immutable once created. To change a dynamic policy, it should be deleted and recreated with the desired changes. This approach ensures that policy changes are auditable and traceable.
 - Implement auditing and logging for all policy changes, including who made the change, when it was made, and what the change was. This is crucial for maintaining security and compliance.
 
 #. Authorization Source of Truth
@@ -71,13 +73,13 @@ Version Static Policies and Make Dynamic Policies Immutable
 
 Make the Policy Store the Single Source of Truth
 ------------------------------------------------
-- The ``model.conf`` with the Casbin model configuration (``model.conf``) and the policy store (via MySQL adapter) together form the single source of truth for authorization in Open edX.
+- The ``model.conf`` with the Casbin model configuration (``model.conf``) and the policy store (via Django ORM adapter) together form the single source of truth for authorization in Open edX.
 - The policy store contains all dynamic policies and the static policies loaded from the ``authz.policy`` files at service initialization.
 - The policy store is the single source of truth for authorization rules. By default, services share the same store to ensure consistency and avoid conflicts.
 
 Allow Shared or Separate Policy Stores as Needed
 ------------------------------------------------
-- By default, all services share the same policy store to ensure consistency and avoid conflicts.
+- By default, all services share the same policy store (LMS) to ensure consistency and avoid conflicts.
 - If isolation between services is required, this can be achieved in two ways: (1) by using a namespace or domain field in the shared table, or (2) by creating a separate policy store for a specific service.
 
 #. Authorization Ownership
@@ -85,7 +87,7 @@ Allow Shared or Separate Policy Stores as Needed
 
 Delegate Policy Ownership to Services
 -------------------------------------
-- Services are responsible for defining their own policies in the ``authz.policy`` files and managing their own dynamic policies via the Policy Management API.
+- Services are responsible for defining their own policies in the ``authz.policy`` files and managing their own dynamic policies via the Role Management API.
 - These policies are managed by each service according to its domain. For example, the LMS manages courseware access policies, while the CMS manages content creation policies.
 - Authorization decisions must always be answered by the service that owns the relevant data and policies (policy owner). For instance, the LMS decides whether a user can access a course because it owns enrollments and courseware data. The CMS decides whether a user can edit content because it owns the content data.
 - The policy store is by default shared across services, but each service is responsible for its own policies and authorization decisions.
@@ -122,7 +124,7 @@ Consequences
 
 #. **Static Policies will be Immutable**: Policies defined in the ``authz.policy`` files will be immutable after being loaded into the policy store. For a policy to be removed, should go through a deprecation cycle where it is first marked as deprecated and then removed in a future version.
 
-#. **Each Service Should Define Its Own Policies (``authz.policy``)**: Each service is responsible for defining its own policies in the ``authz.policy`` files and managing its own dynamic policies via the Policy Management API. This ensures that services can tailor their authorization rules to their specific needs while maintaining a clear boundary of responsibility. If no defaults are defined, the service will start with an empty policy set.
+#. **Each Service Should Define Its Own Policies (``authz.policy``)**: Each service is responsible for defining its own policies in the ``authz.policy`` files and managing its own dynamic policies via the Role Management API. This ensures that services can tailor their authorization rules to their specific needs while maintaining a clear boundary of responsibility. If no defaults are defined, the service will start with an empty policy set.
 
 #. **Clients Share the Same Policy Store**: By default, all services share the same policy store to ensure consistency and avoid conflicts. This means that policies defined by one service can affect authorization decisions in another service.
 

--- a/docs/decisions/0006-policy-store-and-enforcement-model.rst
+++ b/docs/decisions/0006-policy-store-and-enforcement-model.rst
@@ -26,11 +26,6 @@ Use a Casbin Model CONF that Supports Core Principles
 - Favor simple matchers to improve performance and maintainability. This means avoiding complex regexes and nested logic where possible.
 - Use Casbin's built-in support for role hierarchies (g, g2) to manage role inheritance and simplify policy definitions.
 
-Do not Handle Grouping and Context Inheritance via Casbin's Built-in Mechanisms
--------------------------------------------------------------------------------
-- Grouping resources will not be implemented via Casbin's built-in grouping mechanisms (g, g2) but will be explicitly managed when checking permissions in the application layer. For example, if a user has the ``course_admin`` role in ``org:123``, this will not automatically grant them the ``course_admin`` role in all courses within that org. Instead, the application layer will need to check both the user's role and the specific context (e.g., organization or course) when making authorization decisions.
-- Define roles that are context-specific, such as ``course_admin`` for a specific course or ``org_admin`` for a specific organization.
-
 Establish Naming Conventions for Subjects, Actions, Objects, and Contexts
 -------------------------------------------------------------------------
 - Favor the use of simple and easy to read matchers and policies to keep the system maintainable. Revisit complexity if needed.
@@ -117,8 +112,6 @@ Consequences
 #. **ABAC will be Supported Eventually via Custom Matchers**: While the initial implementation will focus on RBAC, the Casbin model will be designed to support ABAC features in the future. This will be achieved through the use of custom matchers that can evaluate attributes of subjects, actions, objects, and contexts.
 
 #. **Default Deny Policy**: The default behavior of the authorization engine will be to deny access unless explicitly allowed by a policy. This is a security best practice that minimizes the risk of unauthorized access.
-
-#. **Grouping will be Handled in the Application Layer**: Instead of using Casbin's built-in grouping mechanisms, the application layer will handle grouping and context inheritance. This provides greater flexibility and allows for more complex authorization logic that is specific to the application's needs.
 
 #. **The Casbin Table Schema will Include Metadata**: The policy store schema will include metadata fields to differentiate between static and dynamic policies. This allows for better management and auditing of policies.
 

--- a/docs/decisions/0007-consistency-and-policy-lifecycle.rst
+++ b/docs/decisions/0007-consistency-and-policy-lifecycle.rst
@@ -1,0 +1,2 @@
+Use Cache to Optimize Data Access
+---------------------------------

--- a/docs/decisions/0007-consistency-and-policy-lifecycle.rst
+++ b/docs/decisions/0007-consistency-and-policy-lifecycle.rst
@@ -1,2 +1,0 @@
-Use Cache to Optimize Data Access
----------------------------------

--- a/docs/references/glossary.rst
+++ b/docs/references/glossary.rst
@@ -1,0 +1,171 @@
+Glossary
+########
+
+.. glossary::
+   :sorted:
+
+   Action
+      The operation attempted on a resource (e.g., ``view``, ``edit``, ``delete``). Actions use
+      snake_case when composed of multiple words (e.g., ``view_grades``). In the :term:`namespace
+      convention<Namespace Convention>`, actions are prefixed with ``act^`` (e.g.,
+      ``act^content_libraries.view_library``).
+
+   Adapter
+      A component that connects the :term:`Authorization Engine` to a data backend for policy
+      storage and retrieval. In openedx-authz, the ``ExtendedAdapter`` uses the Django ORM to
+      read and write policies in the database, supporting filtered loading for performance.
+
+   Attribute
+      A property of a :term:`Subject`, :term:`Resource`, or context used in :term:`ABAC` decisions
+      (e.g., ``user.profile.department``, ``course.org``). Attributes enable finer-grained control
+      beyond role membership.
+
+   Authorization Check
+      The act of asking whether an operation is allowed. Always expressed in :term:`S-A-O-C` form:
+      *is Subject allowed to perform Action on Object under Context?*
+
+   Authorization Engine
+      The Casbin-based component that evaluates :term:`authorization checks<Authorization Check>`
+      against defined policies and returns allow/deny decisions. It loads policies from the
+      :term:`Policy Store`, applies the :term:`matcher<Matcher>` logic defined in the
+      :term:`model configuration<Model Configuration>`, and is accessed through the
+      :term:`Open edX Layer`.
+
+   ABAC
+      Attribute-Based Access Control. An :term:`authorization model<Authorization Model>` where
+      access decisions are based on attributes of the :term:`subject<Subject>`, object, and context
+      (e.g., user's organization, resource type, time of day). ABAC is the long-term goal for
+      Open edX authorization.
+
+   Authorization Model
+      A framework or approach that defines how to express who can do what, on which
+      :term:`resource<Resource>`, and under which conditions. See :term:`RBAC`, :term:`ABAC`,
+      and :term:`ReBAC`.
+
+   Dynamic Policy
+      A :term:`policy<Policy>` created at runtime through the :term:`Role Management API` or
+      Django Admin. Dynamic policies include :term:`role<Role>` assignments (granting a user a role
+      in a :term:`scope<Scope>`) and operator-defined policy additions. They are mutable via
+      the API but immutable once created (delete and recreate to change). Contrast with
+      :term:`Static Policy`.
+
+   Enforcement API
+      The public interface through which services request authorization decisions. It consists of
+      the Public Python API (``openedx_authz.api``) for in-process clients and the REST API for
+      remote clients. Services call the Enforcement API with :term:`subject<Subject>`,
+      :term:`action<Action>`, and :term:`scope<Scope>`, and receive an allow/deny decision.
+
+   Enforcer
+      The runtime instance of the :term:`Authorization Engine` that evaluates authorization
+      requests. Implemented as a singleton (``AuthzEnforcer``) wrapping Casbin's
+      ``SyncedEnforcer``, it loads policies from the :term:`Policy Store` and reloads them when
+      the policy version changes.
+
+   Feature Flag
+      A toggle that controls whether a feature is active. In the AuthZ context, Waffle flags
+      control the cutover from legacy authorization to the new system per course, organization,
+      or instance. See ADR 0010.
+
+   Matcher
+      The logic in the :term:`model configuration<Model Configuration>` that determines whether a
+      :term:`policy<Policy>` applies to a given request. The matcher checks :term:`subject<Subject>`
+      role membership, :term:`scope<Scope>` patterns (via ``keyMatch``), and :term:`action<Action>`
+      grouping (via ``g2``).
+
+   Model Configuration
+      The Casbin ``model.conf`` file that defines the structure of authorization requests, policies,
+      role definitions, effects, and :term:`matchers<Matcher>`. It is the blueprint for how the
+      :term:`Authorization Engine` interprets and evaluates policies. Shared across all services
+      by default.
+
+   Namespace Convention
+      The naming convention used in policies where a ``^`` separator distinguishes the type prefix
+      from the identifier (e.g., ``user^alice``, ``role^course_admin``, ``act^edit``,
+      ``lib^lib:DemoX:CSPROB``). This prevents ambiguity between authz namespaces and resource
+      identifiers, and enables polymorphic dispatch.
+
+   Open edX Layer
+      The ``openedx_authz`` Django app that encapsulates all authorization logic. It abstracts
+      the :term:`Authorization Engine` internals and provides the :term:`Enforcement API`,
+      :term:`Role Management API`, and policy lifecycle management. Services interact with
+      authorization exclusively through this layer.
+
+   Permission
+      An atomic unit of access that can be granted or denied (e.g., ``CREATE_COURSE``,
+      ``EDIT_ROLE``). Permissions are grouped into :term:`roles<Role>` and expressed as
+      :term:`actions<Action>` in policies.
+
+   Policy
+      A declarative rule that defines which :term:`subjects<Subject>` can perform which
+      :term:`actions<Action>` on which objects under which context, with a specified effect
+      (allow or deny). Policies are stored outside of code in the :term:`Policy Store`, versioned,
+      and auditable. See also :term:`Static Policy` and :term:`Dynamic Policy`.
+
+   Role Management API
+      The interface for managing :term:`role<Role>` assignments, :term:`policies<Policy>`, and
+      :term:`dynamic policies<Dynamic Policy>` in the :term:`Policy Store`. Implemented in
+      ``openedx_authz.api.roles`` (role assignment, unassignment, and queries) and
+      ``openedx_authz.api.users`` (user-oriented convenience wrappers). Accessible through
+      Python functions and management commands within the :term:`Open edX Layer`.
+
+   Policy Store
+      The persistent storage where all authorization policies are kept. Backed by the Django ORM
+      (the ``CasbinRule`` table and related metadata models), it holds both :term:`static
+      policies<Static Policy>` and :term:`dynamic policies<Dynamic Policy>`. The Policy Store is
+      the single source of truth for authorization rules. By default, all services share the
+      same store.
+
+   RBAC
+      Role-Based Access Control. An :term:`authorization model<Authorization Model>` where access
+      is granted based on :term:`roles<Role>` assigned to users (e.g., "admins can edit any
+      record"). See also :term:`Scoped RBAC`.
+
+   ReBAC
+      Relationship-Based Access Control. An :term:`authorization model<Authorization Model>` where
+      access decisions are based on explicit relationships between :term:`subjects<Subject>` and
+      objects, often modeled as a graph. Not adopted for Open edX due to added complexity and
+      lack of strong use cases.
+
+   Resource
+      The object being accessed or acted upon (e.g., a course, a content library, an organization).
+      In policies, resources are identified within the :term:`scope<Scope>` field using the
+      :term:`namespace convention<Namespace Convention>`.
+
+   Role
+      A named collection of :term:`permissions<Permission>` that can be assigned to a
+      :term:`subject<Subject>` within a :term:`scope<Scope>` (e.g., ``course_admin``,
+      ``library_editor``). Roles are defined in :term:`static policies<Static Policy>` and
+      assigned to users via :term:`dynamic policies<Dynamic Policy>`.
+
+   S-A-O-C
+      Subject-Action-Object-Context. The canonical shape of any :term:`authorization
+      check<Authorization Check>`: *is Subject allowed to perform Action on Object under Context?*
+      All authorization decisions in Open edX are normalized to this form.
+
+   Scope
+      The boundary within which a :term:`role<Role>` or :term:`policy<Policy>` applies (e.g.,
+      platform-wide, organization-wide, a single course, or a specific library). Scopes are
+      first-class citizens in the authorization model: explicitly modeled, parameterized (e.g.,
+      ``org^OpenedX``, ``course-v1^course-v1:Org+Course+Run``), and available to policies,
+      queries, and audits.
+
+   Scoped RBAC
+      A variant of :term:`RBAC` where :term:`roles<Role>` apply within a specific
+      :term:`scope<Scope>` (e.g., ``course_admin`` for a particular course, ``org_admin`` for a
+      particular organization). Used as the pragmatic first step toward :term:`ABAC`.
+
+   Static Policy
+      A :term:`policy<Policy>` defined in the ``authz.policy`` file shipped with the package.
+      Static policies define default role-permission mappings and action groupings. They are loaded
+      into the :term:`Policy Store` at deployment time via the ``load_policies`` management command
+      and are immutable after load. Contrast with :term:`Dynamic Policy`.
+
+   Subject
+      The entity requesting access. Typically a user (e.g., ``user^alice``) but can also be a
+      service (e.g., ``service^lms``). In the :term:`namespace convention<Namespace Convention>`,
+      subjects carry a type prefix that identifies the kind of entity.
+
+   Watcher
+      A mechanism for distributed policy synchronization. When one service instance updates
+      policies in the :term:`Policy Store`, the watcher notifies other instances to reload their
+      in-memory policy state, keeping :term:`enforcers<Enforcer>` consistent across a cluster.

--- a/docs/references/index.rst
+++ b/docs/references/index.rst
@@ -1,2 +1,7 @@
 References
 ##########
+
+.. toctree::
+   :maxdepth: 2
+
+   glossary


### PR DESCRIPTION
## Description
ADR for policy and model (all casbin-related concepts) management fit to our environment. In this ADR we make decisions for:
- The authorization engine configuration (model.conf) which tells the system how to behave
- Magement of authz.policy and the policy store
- Make the policy store the source of truth for authorization

**Merge checklist:**
Check off if complete *or* not applicable:
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Fixup commits are squashed away
- [ ] Unit tests added/updated
- [ ] Manual testing instructions provided
- [ ] Noted any: Concerns, dependencies, migration issues, deadlines, tickets
