### PR TITLE
[FC-0099] refactor: read from system settings before declaring default configs

### DIFF
--- a/openedx_authz/engine/watcher.py
+++ b/openedx_authz/engine/watcher.py
@@ -40,8 +40,8 @@ def create_watcher():
         The configured watcher instance
     """
     watcher_options = WatcherOptions()
-    watcher_options.host = settings.REDIS_HOST
-    watcher_options.port = settings.REDIS_PORT
+    watcher_options.host = settings.CASBIN_WATCHER_REDIS_HOST
+    watcher_options.port = settings.CASBIN_WATCHER_REDIS_PORT
     watcher_options.optional_update_callback = callback_function
 
     try:

--- a/openedx_authz/management/commands/load_policies.py
+++ b/openedx_authz/management/commands/load_policies.py
@@ -9,6 +9,7 @@ The command supports:
 import os
 
 import casbin
+from django.conf import settings
 from django.core.management.base import BaseCommand
 
 from openedx_authz import ROOT_DIRECTORY
@@ -65,12 +66,12 @@ class Command(BaseCommand):
         """
         policy_file_path, model_file_path = options["policy_file_path"], options["model_file_path"]
         if policy_file_path is None:
-            policy_file_path = os.path.join(
-                ROOT_DIRECTORY, "engine", "config", "authz.policy"
+            policy_file_path = getattr(
+                settings, "CASBIN_POLICY_DEFAULTS", os.path.join(ROOT_DIRECTORY, "engine", "config", "authz.policy")
             )
         if model_file_path is None:
-            model_file_path = os.path.join(
-                ROOT_DIRECTORY, "engine", "config", "model.conf"
+            model_file_path = getattr(
+                settings, "CASBIN_MODEL", os.path.join(ROOT_DIRECTORY, "engine", "config", "model.conf")
             )
 
         source_enforcer = casbin.Enforcer(model_file_path, policy_file_path)

--- a/openedx_authz/settings/common.py
+++ b/openedx_authz/settings/common.py
@@ -21,11 +21,16 @@ def plugin_settings(settings):
     if casbin_adapter_app not in settings.INSTALLED_APPS:
         settings.INSTALLED_APPS.append(casbin_adapter_app)
     # Add Casbin configuration
-    settings.CASBIN_MODEL = os.path.join(
-        ROOT_DIRECTORY, "engine", "config", "model.conf"
-    )
-    settings.CASBIN_WATCHER_ENABLED = False
+    if not getattr(settings, "CASBIN_MODEL", None):
+        settings.CASBIN_MODEL = os.path.join(ROOT_DIRECTORY, "engine", "config", "model.conf")
+    if not getattr(settings, "CASBIN_POLICY_DEFAULTS", None):
+        settings.CASBIN_POLICY_DEFAULTS = os.path.join(ROOT_DIRECTORY, "engine", "config", "authz.policy")
+    if not getattr(settings, "CASBIN_WATCHER_ENABLED", None):
+        settings.CASBIN_WATCHER_ENABLED = False
+
     # TODO: Replace with a more dynamic configuration
     # Redis host and port are temporarily loaded here for the MVP
-    settings.REDIS_HOST = "redis"
-    settings.REDIS_PORT = 6379
+    if not getattr(settings, "CASBIN_WATCHER_REDIS_HOST", None):
+        settings.CASBIN_WATCHER_REDIS_HOST = "redis"
+    if not getattr(settings, "CASBIN_WATCHER_REDIS_PORT", None):
+        settings.CASBIN_WATCHER_REDIS_PORT = 6379

--- a/openedx_authz/settings/test.py
+++ b/openedx_authz/settings/test.py
@@ -9,8 +9,8 @@ from openedx_authz import ROOT_DIRECTORY
 # Add Casbin configuration
 CASBIN_MODEL = os.path.join(ROOT_DIRECTORY, "engine", "config", "model.conf")
 # Redis host and port are temporarily loaded here for the MVP
-REDIS_HOST = "redis"
-REDIS_PORT = 6379
+CASBIN_WATCHER_REDIS_HOST = "redis"
+CASBIN_WATCHER_REDIS_PORT = 6379
 DATABASES = {
     "default": {
         "ENGINE": "django.db.backends.sqlite3",


### PR DESCRIPTION
## Description

Read from current Django settings before using defaults to prevent overrides (and allow more flexibility) in deployment strategies like tutor.