### PR TITLE
[FC-0099] fix: update permissions for role list view

### DIFF
--- a/openedx_authz/rest_api/v1/views.py
+++ b/openedx_authz/rest_api/v1/views.py
@@ -442,7 +442,7 @@ class RoleListView(APIView):
             status.HTTP_401_UNAUTHORIZED: "The user is not authenticated or does not have the required permissions",
         },
     )
-    @authz_permissions(["manage_library_team"])
+    @authz_permissions(["view_library_team"])
     def get(self, request: HttpRequest) -> Response:
         """Retrieve all roles and their permissions for a specific scope."""
         serializer = ListRolesWithScopeSerializer(data=request.query_params)


### PR DESCRIPTION
### Description

The **get roles by scope** endpoint should require the `view_library_team` permission instead of `manage_library_team`, since all library roles (`library_admin`, `library_author`, `library_collaborator`, and `library_user`) should have permission to view the roles and their associated permissions.

### Supporting Information

- https://github.com/openedx/openedx-authz/issues/53

### Testing Instructions

Using Tutor:

1. Install this plugin with the changes in this PR.
2. Run the migrations by running `tutor dev exec lms python manage.py lms migrate`
3. Load the default policies by running `tutor dev exec lms python manage.py lms load_policies`
4. Use the `/api/authz/v1/roles/?scope={library-id}` endpoint with users with different roles (`library_admin`, `library_author`, `library_collaborator`, and `library_user`)
5. You should have permissions to view.

### Merge Checklist
Check off if complete *or* not applicable:
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [x] Fixup commits are squashed away
- [x] Unit tests added/updated
- [x] Manual testing instructions provided
- [x] Noted any: Concerns, dependencies, migration issues, deadlines, tickets
