### PR TITLE
fix: use correctly the libraries_v2_enabled function

### DIFF
--- a/openedx_authz/engine/enforcer.py
+++ b/openedx_authz/engine/enforcer.py
@@ -27,12 +27,9 @@ try:
     from cms.djangoapps.contentstore.toggles import libraries_v2_enabled
 except ImportError:
     # If the CMS is not available, define a dummy toggle that is always enabled
-    class DummyToggle:
-        @staticmethod
-        def is_enabled():
-            return True
-
-    libraries_v2_enabled = DummyToggle()
+    def libraries_v2_enabled() -> bool:
+        """Dummy toggle that is always enabled."""
+        return True
 
 
 logger = logging.getLogger(__name__)
@@ -162,7 +159,7 @@ class AuthzEnforcer:
         # removed for the next release cycle.
         # When replaced, we will only need to configure the enforcer here. Which
         # is in charge of enabling/disabling auto-load and auto-save.
-        if libraries_v2_enabled.is_enabled():
+        if libraries_v2_enabled():
             cls.configure_enforcer_auto_save_and_load()
         else:
             cls.deactivate_enforcer()

--- a/openedx_authz/tests/test_enforcer.py
+++ b/openedx_authz/tests/test_enforcer.py
@@ -590,7 +590,7 @@ class TestEnforcerToggleBehavior(TransactionTestCase):
             - Policy changes are persisted to database
             - CASBIN_AUTO_LOAD_POLICY_INTERVAL=0 doesn't disable auto-save
         """
-        mock_toggle.is_enabled.return_value = True
+        mock_toggle.return_value = True
 
         enforcer = AuthzEnforcer.get_enforcer()
 
@@ -619,7 +619,7 @@ class TestEnforcerToggleBehavior(TransactionTestCase):
             - Auto-save is disabled via deactivate_enforcer
             - Auto-load is stopped
         """
-        mock_toggle.is_enabled.return_value = False
+        mock_toggle.return_value = False
 
         enforcer = AuthzEnforcer.get_enforcer()
 
@@ -635,7 +635,7 @@ class TestEnforcerToggleBehavior(TransactionTestCase):
             - Auto-load thread is started with configured interval
             - Auto-save is enabled
         """
-        mock_toggle.is_enabled.return_value = True
+        mock_toggle.return_value = True
 
         enforcer = AuthzEnforcer.get_enforcer()
 
@@ -652,7 +652,7 @@ class TestEnforcerToggleBehavior(TransactionTestCase):
             - Subsequent calls don't restart the auto-load thread
             - Auto-save remains enabled
         """
-        mock_toggle.is_enabled.return_value = True
+        mock_toggle.return_value = True
 
         enforcer1 = AuthzEnforcer.get_enforcer()
         self.assertTrue(enforcer1.is_auto_loading_running())
@@ -674,11 +674,11 @@ class TestEnforcerToggleBehavior(TransactionTestCase):
             - First call with toggle off: auto-save disabled
             - Second call with toggle on: auto-save enabled
         """
-        mock_toggle.is_enabled.return_value = False
+        mock_toggle.return_value = False
         enforcer1 = AuthzEnforcer.get_enforcer()
         self.assertFalse(AuthzEnforcer.is_auto_save_enabled())
 
-        mock_toggle.is_enabled.return_value = True
+        mock_toggle.return_value = True
         enforcer2 = AuthzEnforcer.get_enforcer()
         self.assertIs(enforcer1, enforcer2)
         self.assertTrue(AuthzEnforcer.is_auto_save_enabled())
@@ -696,7 +696,7 @@ class TestEnforcerToggleBehavior(TransactionTestCase):
             - Enforcer initializes successfully
             - Auto-save is enabled (DummyToggle returns True)
         """
-        mock_toggle.is_enabled.return_value = True
+        mock_toggle.return_value = True
 
         enforcer = AuthzEnforcer.get_enforcer()
 
@@ -715,7 +715,7 @@ class TestEnforcerToggleBehavior(TransactionTestCase):
             - Tests can manually enable auto-save
             - Subsequent get_enforcer() calls preserve auto-save state
         """
-        mock_toggle.is_enabled.return_value = True
+        mock_toggle.return_value = True
 
         enforcer = AuthzEnforcer.get_enforcer()
         enforcer.enable_auto_save(True)
@@ -735,7 +735,7 @@ class TestEnforcerToggleBehavior(TransactionTestCase):
             - Policies added via add_policy() are persisted to database
             - Policies can be reloaded from database
         """
-        mock_toggle.is_enabled.return_value = True
+        mock_toggle.return_value = True
 
         enforcer = AuthzEnforcer.get_enforcer()
         enforcer.enable_auto_save(True)
@@ -763,7 +763,7 @@ class TestEnforcerToggleBehavior(TransactionTestCase):
             - Auto-save is disabled
             - Auto-load is not running
         """
-        mock_toggle.is_enabled.return_value = True
+        mock_toggle.return_value = True
 
         enforcer = AuthzEnforcer.get_enforcer()
 
@@ -779,7 +779,7 @@ class TestEnforcerToggleBehavior(TransactionTestCase):
             - Policies added are only in memory
             - Reloading from database clears them
         """
-        mock_toggle.is_enabled.return_value = True
+        mock_toggle.return_value = True
 
         enforcer = AuthzEnforcer.get_enforcer()
 
@@ -812,7 +812,7 @@ class TestEnforcerToggleBehavior(TransactionTestCase):
             - After manually enabling auto-save, it stays enabled
             - Multiple get_enforcer() calls don't change auto-save state
         """
-        mock_toggle.is_enabled.return_value = True
+        mock_toggle.return_value = True
 
         # First call
         enforcer1 = AuthzEnforcer.get_enforcer()


### PR DESCRIPTION
### Description

This PR fixes the use of `libraries_v2_enabled` because it is a function, not a class.

### Merge checklist:
Check off if complete *or* not applicable:
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Fixup commits are squashed away
- [ ] Unit tests added/updated
- [ ] Manual testing instructions provided
- [ ] Noted any: Concerns, dependencies, migration issues, deadlines, tickets
