### PR TITLE
docs: add that staff and superusers are like admins on all libs

### DIFF
--- a/docs/concepts/core_roles_and_permissions/content_library_roles.rst
+++ b/docs/concepts/core_roles_and_permissions/content_library_roles.rst
@@ -20,6 +20,10 @@ A **role** is a set of permissions that defines what actions a user can perform.
 
 - The **Library User** can view and reuse content but cannot edit or delete anything.
 
+.. note::
+
+   Global staff and superusers are like Library Admins on all libraries (they have full permissions across all content libraries by default).
+
 Permissions
 -----------
 


### PR DESCRIPTION
## Description
I added the following note:
<img width="824" height="514" alt="image" src="https://github.com/user-attachments/assets/8cb726bf-fb6e-4db7-887b-1325d525cfe6" />

## How to test

Link: https://openedx-authz--153.org.readthedocs.build/en/153/concepts/core_roles_and_permissions/content_library_roles.html#roles

**Merge checklist:**
Check off if complete *or* not applicable:
- [ ] Version bumped
- [ ] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Fixup commits are squashed away
- [x] Unit tests added/updated
- [x] Manual testing instructions provided
- [x] Noted any: Concerns, dependencies, migration issues, deadlines, tickets
