### PR TITLE
docs: Add crossreference for docs linking

### DIFF
--- a/docs/concepts/core_roles_and_permissions/content_library_roles.rst
+++ b/docs/concepts/core_roles_and_permissions/content_library_roles.rst
@@ -1,3 +1,5 @@
+.. _Roles Permissions Content Library:
+
 Core Roles and Permissions: Content Library
 #############################################
 


### PR DESCRIPTION
Add crossref so I can link in https://github.com/openedx/docs.openedx.org/pull/1351