### PR TITLE
chore: Fix and run make upgrade

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -18,10 +18,8 @@ cffi==2.0.0
     #   pynacl
 charset-normalizer==3.4.3
     # via requests
-click==8.3.0
-    # via
-    #   -c requirements/constraints.txt
-    #   edx-django-utils
+click==8.3.1
+    # via edx-django-utils
 cryptography==46.0.2
     # via pyjwt
 django==4.2.24
@@ -56,7 +54,7 @@ drf-jwt==1.19.2
     # via edx-drf-extensions
 drf-yasg==1.21.11
     # via edx-api-doc-tools
-edx-api-doc-tools==2.1.0
+edx-api-doc-tools==2.1.2
     # via -r requirements/base.in
 edx-django-utils==8.0.1
     # via
@@ -74,7 +72,7 @@ inflection==0.5.1
     # via drf-yasg
 openedx-atlas==0.7.0
     # via -r requirements/base.in
-packaging==25.0
+packaging==26.0
     # via drf-yasg
 psutil==7.1.0
     # via edx-django-utils

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file=requirements/ci.txt requirements/ci.in
 #
-cachetools==6.2.0
+cachetools==6.2.6
     # via tox
 chardet==5.2.0
     # via tox
@@ -12,23 +12,23 @@ colorama==0.4.6
     # via tox
 distlib==0.4.0
     # via virtualenv
-filelock==3.19.1
+filelock==3.20.3
     # via
     #   tox
     #   virtualenv
-packaging==25.0
+packaging==26.0
     # via
     #   pyproject-api
     #   tox
-platformdirs==4.4.0
+platformdirs==4.5.1
     # via
     #   tox
     #   virtualenv
 pluggy==1.6.0
     # via tox
-pyproject-api==1.9.1
+pyproject-api==1.10.0
     # via tox
-tox==4.30.2
+tox==4.34.1
     # via -r requirements/ci.in
-virtualenv==20.34.0
+virtualenv==20.36.1
     # via tox

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -10,6 +10,3 @@
 
 # Common constraints for edx repos
 -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
-
-# Different packages want different versions of click, we force the most compatible one here
-click==8.3.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -8,7 +8,7 @@ asgiref==3.9.1
     # via
     #   -r requirements/quality.txt
     #   django
-astroid==3.3.11
+astroid==4.0.3
     # via
     #   -r requirements/quality.txt
     #   pylint
@@ -19,7 +19,7 @@ build==1.4.0
     # via
     #   -r requirements/pip-tools.txt
     #   pip-tools
-cachetools==6.2.0
+cachetools==6.2.6
     # via
     #   -r requirements/ci.txt
     #   tox
@@ -43,9 +43,8 @@ charset-normalizer==3.4.3
     # via
     #   -r requirements/quality.txt
     #   requests
-click==8.3.0
+click==8.3.1
     # via
-    #   -c requirements/constraints.txt
     #   -r requirements/pip-tools.txt
     #   -r requirements/quality.txt
     #   click-log
@@ -127,7 +126,7 @@ drf-yasg==1.21.11
     # via
     #   -r requirements/quality.txt
     #   edx-api-doc-tools
-edx-api-doc-tools==2.1.0
+edx-api-doc-tools==2.1.2
     # via -r requirements/quality.txt
 edx-django-utils==8.0.1
     # via
@@ -143,7 +142,7 @@ edx-opaque-keys==3.0.0
     # via
     #   -r requirements/quality.txt
     #   edx-drf-extensions
-filelock==3.19.1
+filelock==3.20.3
     # via
     #   -r requirements/ci.txt
     #   tox
@@ -185,7 +184,7 @@ mccabe==0.7.0
     #   pylint
 openedx-atlas==0.7.0
     # via -r requirements/quality.txt
-packaging==25.0
+packaging==26.0
     # via
     #   -r requirements/ci.txt
     #   -r requirements/pip-tools.txt
@@ -195,11 +194,12 @@ packaging==25.0
     #   pyproject-api
     #   pytest
     #   tox
+    #   wheel
 path==16.16.0
     # via edx-i18n-tools
 pip-tools==7.5.2
     # via -r requirements/pip-tools.txt
-platformdirs==4.4.0
+platformdirs==4.5.1
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
@@ -240,7 +240,7 @@ pyjwt[crypto]==2.10.1
     #   -r requirements/quality.txt
     #   drf-jwt
     #   edx-drf-extensions
-pylint==3.3.8
+pylint==4.0.4
     # via
     #   -r requirements/quality.txt
     #   edx-lint
@@ -251,7 +251,7 @@ pylint-celery==0.3
     # via
     #   -r requirements/quality.txt
     #   edx-lint
-pylint-django==2.6.1
+pylint-django==2.7.0
     # via
     #   -r requirements/quality.txt
     #   edx-lint
@@ -268,7 +268,7 @@ pynacl==1.6.0
     # via
     #   -r requirements/quality.txt
     #   edx-django-utils
-pyproject-api==1.9.1
+pyproject-api==1.10.0
     # via
     #   -r requirements/ci.txt
     #   tox
@@ -340,7 +340,7 @@ tomlkit==0.13.3
     # via
     #   -r requirements/quality.txt
     #   pylint
-tox==4.30.2
+tox==4.34.1
     # via -r requirements/ci.txt
 typing-extensions==4.15.0
     # via
@@ -354,11 +354,11 @@ urllib3==2.5.0
     # via
     #   -r requirements/quality.txt
     #   requests
-virtualenv==20.34.0
+virtualenv==20.36.1
     # via
     #   -r requirements/ci.txt
     #   tox
-wheel==0.45.1
+wheel==0.46.3
     # via
     #   -r requirements/pip-tools.txt
     #   pip-tools

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -39,9 +39,8 @@ charset-normalizer==3.4.3
     # via
     #   -r requirements/test.txt
     #   requests
-click==8.3.0
+click==8.3.1
     # via
-    #   -c requirements/constraints.txt
     #   -r requirements/test.txt
     #   code-annotations
     #   edx-django-utils
@@ -108,7 +107,7 @@ drf-yasg==1.21.11
     # via
     #   -r requirements/test.txt
     #   edx-api-doc-tools
-edx-api-doc-tools==2.1.0
+edx-api-doc-tools==2.1.2
     # via -r requirements/test.txt
 edx-django-utils==8.0.1
     # via
@@ -171,7 +170,7 @@ nh3==0.3.0
     # via readme-renderer
 openedx-atlas==0.7.0
     # via -r requirements/test.txt
-packaging==25.0
+packaging==26.0
     # via
     #   -r requirements/test.txt
     #   build

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -6,19 +6,19 @@
 #
 build==1.4.0
     # via pip-tools
-click==8.3.0
+click==8.3.1
+    # via pip-tools
+packaging==26.0
     # via
-    #   -c requirements/constraints.txt
-    #   pip-tools
-packaging==25.0
-    # via build
+    #   build
+    #   wheel
 pip-tools==7.5.2
     # via -r requirements/pip-tools.in
 pyproject-hooks==1.2.0
     # via
     #   build
     #   pip-tools
-wheel==0.45.1
+wheel==0.46.3
     # via pip-tools
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -4,11 +4,13 @@
 #
 #    pip-compile --allow-unsafe --output-file=requirements/pip.txt requirements/pip.in
 #
-wheel==0.45.1
+packaging==26.0
+    # via wheel
+wheel==0.46.3
     # via -r requirements/pip.in
 
 # The following packages are considered to be unsafe in a requirements file:
 pip==25.3
     # via -r requirements/pip.in
-setuptools==80.9.0
+setuptools==80.10.2
     # via -r requirements/pip.in

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -8,7 +8,7 @@ asgiref==3.9.1
     # via
     #   -r requirements/test.txt
     #   django
-astroid==3.3.11
+astroid==4.0.3
     # via
     #   pylint
     #   pylint-celery
@@ -29,9 +29,8 @@ charset-normalizer==3.4.3
     # via
     #   -r requirements/test.txt
     #   requests
-click==8.3.0
+click==8.3.1
     # via
-    #   -c requirements/constraints.txt
     #   -r requirements/test.txt
     #   click-log
     #   code-annotations
@@ -96,7 +95,7 @@ drf-yasg==1.21.11
     # via
     #   -r requirements/test.txt
     #   edx-api-doc-tools
-edx-api-doc-tools==2.1.0
+edx-api-doc-tools==2.1.2
     # via -r requirements/test.txt
 edx-django-utils==8.0.1
     # via
@@ -136,12 +135,12 @@ mccabe==0.7.0
     # via pylint
 openedx-atlas==0.7.0
     # via -r requirements/test.txt
-packaging==25.0
+packaging==26.0
     # via
     #   -r requirements/test.txt
     #   drf-yasg
     #   pytest
-platformdirs==4.4.0
+platformdirs==4.5.1
     # via pylint
 pluggy==1.6.0
     # via
@@ -171,7 +170,7 @@ pyjwt[crypto]==2.10.1
     #   -r requirements/test.txt
     #   drf-jwt
     #   edx-drf-extensions
-pylint==3.3.8
+pylint==4.0.4
     # via
     #   edx-lint
     #   pylint-celery
@@ -179,7 +178,7 @@ pylint==3.3.8
     #   pylint-plugin-utils
 pylint-celery==0.3
     # via edx-lint
-pylint-django==2.6.1
+pylint-django==2.7.0
     # via edx-lint
 pylint-plugin-utils==0.9.0
     # via

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -25,9 +25,8 @@ charset-normalizer==3.4.3
     # via
     #   -r requirements/base.txt
     #   requests
-click==8.3.0
+click==8.3.1
     # via
-    #   -c requirements/constraints.txt
     #   -r requirements/base.txt
     #   code-annotations
     #   edx-django-utils
@@ -81,7 +80,7 @@ drf-yasg==1.21.11
     # via
     #   -r requirements/base.txt
     #   edx-api-doc-tools
-edx-api-doc-tools==2.1.0
+edx-api-doc-tools==2.1.2
     # via -r requirements/base.txt
 edx-django-utils==8.0.1
     # via
@@ -109,7 +108,7 @@ markupsafe==3.0.2
     # via jinja2
 openedx-atlas==0.7.0
     # via -r requirements/base.txt
-packaging==25.0
+packaging==26.0
     # via
     #   -r requirements/base.txt
     #   drf-yasg


### PR DESCRIPTION
Removes a no longer needed click pin, which cascaded a series of dependency issues.

Note: It has been difficult to get a consistent package version resolution today, we should run the Github action after merge to make sure this continues to work in CI.