### PR TITLE
feat: add api function for get user role assignments filtered

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,15 @@ Change Log
 Unreleased
 **********
 
+1.2.0 - 2026-03-30
+******************
+
+Added
+=====
+
+* Add ``get_user_role_assignments_filtered`` api function to fetch user role assignments filtered by user, role, and/or scope.
+* Add ``org`` property to ``ContentLibraryData`` and ``CourseOverviewData``.
+
 1.1.0 - 2026-03-17
 ******************
 

--- a/openedx_authz/__init__.py
+++ b/openedx_authz/__init__.py
@@ -4,6 +4,6 @@ Open edX AuthZ provides the architecture and foundations of the authorization fr
 
 import os
 
-__version__ = "1.1.0"
+__version__ = "1.2.0"
 
 ROOT_DIRECTORY = os.path.dirname(os.path.abspath(__file__))

--- a/openedx_authz/api/data.py
+++ b/openedx_authz/api/data.py
@@ -449,6 +449,15 @@ class ContentLibraryData(ScopeData):
     ID_SEPARATOR: ClassVar[str] = ":"
 
     @property
+    def org(self) -> str:
+        """Get the organization name from the library key.
+
+        Returns:
+            str: The organization name (e.g., ``DemoX`` from ``lib:DemoX:CSPROB``).
+        """
+        return self.library_key.org
+
+    @property
     def library_id(self) -> str:
         """The library identifier as used in Open edX (e.g., 'lib:DemoX:CSPROB').
 
@@ -551,6 +560,15 @@ class CourseOverviewData(ScopeData):
 
     NAMESPACE: ClassVar[str] = "course-v1"
     ID_SEPARATOR: ClassVar[str] = "+"
+
+    @property
+    def org(self) -> str:
+        """Get the organization name from the course key.
+
+        Returns:
+            str: The organization name (e.g., ``DemoX`` from ``course-v1:DemoX+TestCourse+2024_T1``).
+        """
+        return self.course_key.org
 
     @property
     def course_id(self) -> str:

--- a/openedx_authz/api/data.py
+++ b/openedx_authz/api/data.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import re
 from abc import abstractmethod
 from enum import Enum
+from functools import cached_property
 from typing import Any, ClassVar, Literal, Type
 
 from attrs import define
@@ -468,7 +469,7 @@ class ContentLibraryData(ScopeData):
         """
         return self.external_key
 
-    @property
+    @cached_property
     def library_key(self) -> LibraryLocatorV2:
         """The LibraryLocatorV2 object for the content library.
 
@@ -581,7 +582,7 @@ class CourseOverviewData(ScopeData):
         """
         return self.external_key
 
-    @property
+    @cached_property
     def course_key(self) -> CourseKey:
         """The CourseKey object for the course.
 

--- a/openedx_authz/api/roles.py
+++ b/openedx_authz/api/roles.py
@@ -37,6 +37,7 @@ __all__ = [
     "unassign_role_from_subject_in_scope",
     "batch_unassign_role_from_subjects_in_scope",
     "get_subject_role_assignments_in_scope",
+    "get_subject_role_assignments_for_role",
     "get_subject_role_assignments_for_role_in_scope",
     "get_all_subject_role_assignments_in_scope",
     "get_subject_role_assignments",
@@ -321,6 +322,23 @@ def get_subject_role_assignments_in_scope(subject: SubjectData, scope: ScopeData
             )
         )
     return role_assignments
+
+
+def get_subject_role_assignments_for_role(subject: SubjectData, role: RoleData) -> list[RoleAssignmentData]:
+    """Get role assignments for a subject filtered by a specific role across all scopes.
+
+    Args:
+        subject: The SubjectData object representing the subject.
+        role: The RoleData object representing the role to filter by.
+
+    Returns:
+        list[RoleAssignmentData]: A list of assignments where the subject has the specified role.
+    """
+    return [
+        assignment
+        for assignment in get_subject_role_assignments(subject)
+        if any(assigned_role.namespaced_key == role.namespaced_key for assigned_role in assignment.roles)
+    ]
 
 
 def get_subject_role_assignments_for_role_in_scope(role: RoleData, scope: ScopeData) -> list[RoleAssignmentData]:

--- a/openedx_authz/api/roles.py
+++ b/openedx_authz/api/roles.py
@@ -410,23 +410,6 @@ def get_subject_role_assignments_in_scope(subject: SubjectData, scope: ScopeData
     return role_assignments
 
 
-def get_subject_role_assignments_for_role(subject: SubjectData, role: RoleData) -> list[RoleAssignmentData]:
-    """Get role assignments for a subject filtered by a specific role across all scopes.
-
-    Args:
-        subject: The SubjectData object representing the subject.
-        role: The RoleData object representing the role to filter by.
-
-    Returns:
-        list[RoleAssignmentData]: A list of assignments where the subject has the specified role.
-    """
-    return [
-        assignment
-        for assignment in get_subject_role_assignments(subject)
-        if any(assigned_role.namespaced_key == role.namespaced_key for assigned_role in assignment.roles)
-    ]
-
-
 def get_subject_role_assignments_for_role_in_scope(role: RoleData, scope: ScopeData) -> list[RoleAssignmentData]:
     """Get the subjects assigned to a specific role in a specific scope.
 

--- a/openedx_authz/api/roles.py
+++ b/openedx_authz/api/roles.py
@@ -323,18 +323,18 @@ def _get_field_index_and_values(
         (1, ['role^course_admin', 'course-v1^course-v1:OpenedX+Demo+Course'])
         >>> _get_field_index_and_values(user, None, scope)
         (0, ['user^steve', '', 'course-v1^course-v1:OpenedX+Demo+Course'])
+        >>> _get_field_index_and_values(None, None, scope)
+        (2, ['course-v1^course-v1:OpenedX+Demo+Course'])
     """
-    values = [
-        subject.namespaced_key if subject else "",
-        role.namespaced_key if role else "",
-        scope.namespaced_key if scope else "",
-    ]
+    fields = [subject, role, scope]
+    field_index = 0
 
-    # Find first non-empty value (leftmost defined field)
-    try:
-        field_index = next(idx for idx, value in enumerate(values) if value)
-    except StopIteration:
-        return 0, []
+    for index, field in enumerate(fields):
+        if field is not None:
+            field_index = index
+            break
+
+    values = [field.namespaced_key if field else "" for field in fields]
 
     # Take slice from first defined field
     field_values = values[field_index:]

--- a/openedx_authz/api/roles.py
+++ b/openedx_authz/api/roles.py
@@ -26,22 +26,22 @@ from openedx_authz.engine.enforcer import AuthzEnforcer
 from openedx_authz.models import ExtendedCasbinRule
 
 __all__ = [
-    "get_permissions_for_single_role",
-    "get_permissions_for_roles",
-    "get_all_roles_names",
-    "get_all_roles_in_scope",
-    "get_permissions_for_active_roles_in_scope",
-    "get_role_definitions_in_scope",
     "assign_role_to_subject_in_scope",
     "batch_assign_role_to_subjects_in_scope",
-    "unassign_role_from_subject_in_scope",
     "batch_unassign_role_from_subjects_in_scope",
-    "get_subject_role_assignments_in_scope",
-    "get_subject_role_assignments_for_role",
-    "get_subject_role_assignments_for_role_in_scope",
+    "get_all_roles_in_scope",
+    "get_all_roles_names",
     "get_all_subject_role_assignments_in_scope",
-    "get_subject_role_assignments",
+    "get_permissions_for_active_roles_in_scope",
+    "get_permissions_for_roles",
+    "get_permissions_for_single_role",
+    "get_role_assignments",
+    "get_role_definitions_in_scope",
     "get_scopes_for_subject_and_permission",
+    "get_subject_role_assignments",
+    "get_subject_role_assignments_for_role_in_scope",
+    "get_subject_role_assignments_in_scope",
+    "unassign_role_from_subject_in_scope",
     "unassign_subject_from_all_roles",
 ]
 
@@ -287,6 +287,92 @@ def get_subject_role_assignments(subject: SubjectData) -> list[RoleAssignmentDat
         role_assignments.append(
             RoleAssignmentData(
                 subject=subject,
+                roles=[role],
+                scope=ScopeData(namespaced_key=policy[GroupingPolicyIndex.SCOPE.value]),
+            )
+        )
+    return role_assignments
+
+
+def get_field_index_and_values(
+    subject: SubjectData | None,
+    role: RoleData | None,
+    scope: ScopeData | None,
+) -> tuple[int, list[str]]:
+    """Build field index and values for Casbin's get_filtered_grouping_policy.
+
+    Returns the leftmost non-None field as field_index and a list of consecutive
+    values starting from that index. Empty strings serve as wildcards for positions
+    between specified values.
+
+    Examples:
+        >>> get_field_index_and_values(user, None, None)
+        (0, ['user^steve'])
+        >>> get_field_index_and_values(user, role, None)
+        (0, ['user^steve', 'role^course_admin'])
+        >>> get_field_index_and_values(None, role, scope)
+        (1, ['role^course_admin', 'course-v1^course-v1:OpenedX+Demo+Course'])
+        >>> get_field_index_and_values(user, None, scope)
+        (0, ['user^steve', '', 'course-v1^course-v1:OpenedX+Demo+Course'])
+
+    Args:
+        subject: Optional subject to filter by.
+        role: Optional role to filter by.
+        scope: Optional scope to filter by.
+
+    Returns:
+        tuple: (field_index, field_values) where field_index is the starting position
+            and field_values are the consecutive filter values from that position.
+    """
+    values = [
+        subject.namespaced_key if subject else "",
+        role.namespaced_key if role else "",
+        scope.namespaced_key if scope else "",
+    ]
+
+    # Find first non-empty value (leftmost defined field)
+    try:
+        field_index = next(idx for idx, value in enumerate(values) if value)
+    except StopIteration:
+        return 0, []
+
+    # Take slice from first defined field
+    field_values = values[field_index:]
+
+    # Remove trailing wildcards
+    while field_values and field_values[-1] == "":
+        field_values.pop()
+
+    return field_index, field_values
+
+
+def get_role_assignments(
+    *,
+    subject: SubjectData | None = None,
+    role: RoleData | None = None,
+    scope: ScopeData | None = None,
+) -> list[RoleAssignmentData]:
+    """Get all the roles for a subject across all scopes filtered by the given filters.
+
+    Args:
+        subject: Optional SubjectData object to filter by.
+        role: Optional RoleData object to filter by.
+        scope: Optional ScopeData object to filter by.
+
+    Returns:
+        list[RoleAssignmentData]: A list of RoleAssignmentData objects filtered by the given filters.
+    """
+    enforcer = AuthzEnforcer.get_enforcer()
+    role_assignments = []
+    field_index, field_values = get_field_index_and_values(subject, role, scope)
+    policies = enforcer.get_filtered_grouping_policy(field_index, *field_values)
+
+    for policy in policies:
+        role = RoleData(namespaced_key=policy[GroupingPolicyIndex.ROLE.value])
+        role.permissions = get_permissions_for_single_role(role)
+        role_assignments.append(
+            RoleAssignmentData(
+                subject=SubjectData(namespaced_key=policy[GroupingPolicyIndex.SUBJECT.value]),
                 roles=[role],
                 scope=ScopeData(namespaced_key=policy[GroupingPolicyIndex.SCOPE.value]),
             )

--- a/openedx_authz/api/roles.py
+++ b/openedx_authz/api/roles.py
@@ -294,7 +294,7 @@ def get_subject_role_assignments(subject: SubjectData) -> list[RoleAssignmentDat
     return role_assignments
 
 
-def get_field_index_and_values(
+def _get_field_index_and_values(
     subject: SubjectData | None,
     role: RoleData | None,
     scope: ScopeData | None,
@@ -305,16 +305,6 @@ def get_field_index_and_values(
     values starting from that index. Empty strings serve as wildcards for positions
     between specified values.
 
-    Examples:
-        >>> get_field_index_and_values(user, None, None)
-        (0, ['user^steve'])
-        >>> get_field_index_and_values(user, role, None)
-        (0, ['user^steve', 'role^course_admin'])
-        >>> get_field_index_and_values(None, role, scope)
-        (1, ['role^course_admin', 'course-v1^course-v1:OpenedX+Demo+Course'])
-        >>> get_field_index_and_values(user, None, scope)
-        (0, ['user^steve', '', 'course-v1^course-v1:OpenedX+Demo+Course'])
-
     Args:
         subject: Optional subject to filter by.
         role: Optional role to filter by.
@@ -323,6 +313,16 @@ def get_field_index_and_values(
     Returns:
         tuple: (field_index, field_values) where field_index is the starting position
             and field_values are the consecutive filter values from that position.
+
+     Examples:
+        >>> _get_field_index_and_values(user, None, None)
+        (0, ['user^steve'])
+        >>> _get_field_index_and_values(user, role, None)
+        (0, ['user^steve', 'role^course_admin'])
+        >>> _get_field_index_and_values(None, role, scope)
+        (1, ['role^course_admin', 'course-v1^course-v1:OpenedX+Demo+Course'])
+        >>> _get_field_index_and_values(user, None, scope)
+        (0, ['user^steve', '', 'course-v1^course-v1:OpenedX+Demo+Course'])
     """
     values = [
         subject.namespaced_key if subject else "",
@@ -364,7 +364,7 @@ def get_role_assignments(
     """
     enforcer = AuthzEnforcer.get_enforcer()
     role_assignments = []
-    field_index, field_values = get_field_index_and_values(subject, role, scope)
+    field_index, field_values = _get_field_index_and_values(subject, role, scope)
     policies = enforcer.get_filtered_grouping_policy(field_index, *field_values)
 
     for policy in policies:

--- a/openedx_authz/api/users.py
+++ b/openedx_authz/api/users.py
@@ -23,6 +23,7 @@ from openedx_authz.api.roles import (
     batch_assign_role_to_subjects_in_scope,
     batch_unassign_role_from_subjects_in_scope,
     get_all_subject_role_assignments_in_scope,
+    get_role_assignments,
     get_scopes_for_subject_and_permission,
     get_subject_role_assignments,
     get_subject_role_assignments_for_role,
@@ -41,6 +42,7 @@ __all__ = [
     "get_user_role_assignments",
     "get_user_role_assignments_in_scope",
     "get_user_role_assignments_for_role_in_scope",
+    "get_user_role_assignments_filtered",
     "get_all_user_role_assignments_in_scope",
     "is_user_allowed",
     "get_scopes_for_user_and_permission",
@@ -177,6 +179,33 @@ def get_user_role_assignments_for_role_in_scope(
     return get_subject_role_assignments_for_role_in_scope(
         RoleData(external_key=role_external_key),
         ScopeData(external_key=scope_external_key),
+    )
+
+
+def get_user_role_assignments_filtered(
+    *,
+    user_external_key: str | None = None,
+    role_external_key: str | None = None,
+    scope_external_key: str | None = None,
+) -> list[RoleAssignmentData]:
+    """Get role assignments filtered by user, role, and/or scope.
+
+    This function provides flexible filtering of role assignments by any combination
+    of user, role, and scope. At least one filter parameter should be provided for
+    meaningful results.
+
+    Args:
+        user_external_key: Optional user ID to filter by (e.g., 'john_doe').
+        role_external_key: Optional role name to filter by (e.g., 'library_admin').
+        scope_external_key: Optional scope to filter by (e.g., 'lib:DemoX:CSPROB').
+
+    Returns:
+        list[RoleAssignmentData]: Filtered role assignments.
+    """
+    return get_role_assignments(
+        subject=UserData(external_key=user_external_key) if user_external_key else None,
+        role=RoleData(external_key=role_external_key) if role_external_key else None,
+        scope=ScopeData(external_key=scope_external_key) if scope_external_key else None,
     )
 
 

--- a/openedx_authz/api/users.py
+++ b/openedx_authz/api/users.py
@@ -9,7 +9,14 @@ with the role management system, which uses namespaced subjects
 (e.g., 'user^john_doe').
 """
 
-from openedx_authz.api.data import ActionData, PermissionData, RoleAssignmentData, RoleData, ScopeData, UserData
+from openedx_authz.api.data import (
+    ActionData,
+    PermissionData,
+    RoleAssignmentData,
+    RoleData,
+    ScopeData,
+    UserData,
+)
 from openedx_authz.api.permissions import is_subject_allowed
 from openedx_authz.api.roles import (
     assign_role_to_subject_in_scope,
@@ -18,6 +25,7 @@ from openedx_authz.api.roles import (
     get_all_subject_role_assignments_in_scope,
     get_scopes_for_subject_and_permission,
     get_subject_role_assignments,
+    get_subject_role_assignments_for_role,
     get_subject_role_assignments_for_role_in_scope,
     get_subject_role_assignments_in_scope,
     get_subjects_for_role_in_scope,
@@ -38,6 +46,7 @@ __all__ = [
     "get_scopes_for_user_and_permission",
     "get_users_for_role_in_scope",
     "unassign_all_roles_from_user",
+    "get_user_role_assignments_for_role",
 ]
 
 
@@ -119,6 +128,22 @@ def get_user_role_assignments(user_external_key: str) -> list[RoleAssignmentData
         list[RoleAssignmentData]: A list of role assignments and all their metadata assigned to the user.
     """
     return get_subject_role_assignments(UserData(external_key=user_external_key))
+
+
+def get_user_role_assignments_for_role(user_external_key: str, role_external_key: str) -> list[RoleAssignmentData]:
+    """Get role assignments for a user filtered by a specific role across all scopes.
+
+    Args:
+        user_external_key (str): ID of the user (e.g., 'john_doe').
+        role_external_key (str): Name of the role (e.g., 'instructor').
+
+    Returns:
+        list[RoleAssignmentData]: A list of role assignments for the given user and role.
+    """
+    return get_subject_role_assignments_for_role(
+        UserData(external_key=user_external_key),
+        RoleData(external_key=role_external_key),
+    )
 
 
 def get_user_role_assignments_in_scope(user_external_key: str, scope_external_key: str) -> list[RoleAssignmentData]:

--- a/openedx_authz/api/users.py
+++ b/openedx_authz/api/users.py
@@ -26,7 +26,6 @@ from openedx_authz.api.roles import (
     get_role_assignments,
     get_scopes_for_subject_and_permission,
     get_subject_role_assignments,
-    get_subject_role_assignments_for_role,
     get_subject_role_assignments_for_role_in_scope,
     get_subject_role_assignments_in_scope,
     get_subjects_for_role_in_scope,
@@ -48,7 +47,6 @@ __all__ = [
     "get_scopes_for_user_and_permission",
     "get_users_for_role_in_scope",
     "unassign_all_roles_from_user",
-    "get_user_role_assignments_for_role",
 ]
 
 
@@ -130,22 +128,6 @@ def get_user_role_assignments(user_external_key: str) -> list[RoleAssignmentData
         list[RoleAssignmentData]: A list of role assignments and all their metadata assigned to the user.
     """
     return get_subject_role_assignments(UserData(external_key=user_external_key))
-
-
-def get_user_role_assignments_for_role(user_external_key: str, role_external_key: str) -> list[RoleAssignmentData]:
-    """Get role assignments for a user filtered by a specific role across all scopes.
-
-    Args:
-        user_external_key (str): ID of the user (e.g., 'john_doe').
-        role_external_key (str): Name of the role (e.g., 'instructor').
-
-    Returns:
-        list[RoleAssignmentData]: A list of role assignments for the given user and role.
-    """
-    return get_subject_role_assignments_for_role(
-        UserData(external_key=user_external_key),
-        RoleData(external_key=role_external_key),
-    )
 
 
 def get_user_role_assignments_in_scope(user_external_key: str, scope_external_key: str) -> list[RoleAssignmentData]:

--- a/openedx_authz/tests/api/test_data.py
+++ b/openedx_authz/tests/api/test_data.py
@@ -98,6 +98,28 @@ class TestNamespacedData(TestCase):
 
         self.assertEqual(scope.namespaced_key, expected)
 
+    @data(
+        ("lib:DemoX:CSPROB", "DemoX"),
+        ("lib:Org1:math_101", "Org1"),
+    )
+    @unpack
+    def test_content_library_data_org_property(self, external_key, expected_org):
+        """Test that ContentLibraryData returns the correct organization name."""
+        scope = ContentLibraryData(external_key=external_key)
+
+        self.assertEqual(scope.org, expected_org)
+
+    @data(
+        ("course-v1:DemoX+TestCourse+2024_T1", "DemoX"),
+        ("course-v1:WGU+CS002+2025_T1", "WGU"),
+    )
+    @unpack
+    def test_course_overview_data_org_property(self, external_key, expected_org):
+        """Test that CourseOverviewData returns the correct organization name."""
+        scope = CourseOverviewData(external_key=external_key)
+
+        self.assertEqual(scope.org, expected_org)
+
 
 @ddt
 class TestPolymorphicData(TestCase):

--- a/openedx_authz/tests/api/test_roles.py
+++ b/openedx_authz/tests/api/test_roles.py
@@ -31,6 +31,7 @@ from openedx_authz.api.roles import (
     get_role_definitions_in_scope,
     get_scopes_for_subject_and_permission,
     get_subject_role_assignments,
+    get_subject_role_assignments_for_role,
     get_subject_role_assignments_for_role_in_scope,
     get_subject_role_assignments_in_scope,
     get_subjects_for_role_in_scope,
@@ -602,6 +603,23 @@ class TestRolesAPI(RolesTestSetupMixin):
             # Compare the role part of the assignment
             found = any(expected_role in assignment.roles for assignment in role_assignments)
             self.assertTrue(found, f"Expected role {expected_role} not found in assignments")
+
+    @ddt_data(
+        ("liam", roles.LIBRARY_AUTHOR.external_key, 3),
+        ("eve", roles.LIBRARY_ADMIN.external_key, 1),
+        ("eve", roles.LIBRARY_AUTHOR.external_key, 1),
+        ("eve", roles.LIBRARY_USER.external_key, 1),
+        ("alice", roles.LIBRARY_AUTHOR.external_key, 0),
+        ("non_existent_user", roles.LIBRARY_ADMIN.external_key, 0),
+    )
+    @unpack
+    def test_get_subject_role_assignments_for_role(self, subject_name, role_name, expected_count):
+        """Test retrieving role assignments for a subject filtered by role across all scopes."""
+        role_assignments = get_subject_role_assignments_for_role(
+            SubjectData(external_key=subject_name),
+            RoleData(external_key=role_name),
+        )
+        self.assertEqual(len(role_assignments), expected_count)
 
     @ddt_data(
         (roles.LIBRARY_ADMIN.external_key, "lib:Org1:math_101", 1),

--- a/openedx_authz/tests/api/test_roles.py
+++ b/openedx_authz/tests/api/test_roles.py
@@ -31,7 +31,6 @@ from openedx_authz.api.roles import (
     get_role_definitions_in_scope,
     get_scopes_for_subject_and_permission,
     get_subject_role_assignments,
-    get_subject_role_assignments_for_role,
     get_subject_role_assignments_for_role_in_scope,
     get_subject_role_assignments_in_scope,
     get_subjects_for_role_in_scope,
@@ -603,23 +602,6 @@ class TestRolesAPI(RolesTestSetupMixin):
             # Compare the role part of the assignment
             found = any(expected_role in assignment.roles for assignment in role_assignments)
             self.assertTrue(found, f"Expected role {expected_role} not found in assignments")
-
-    @ddt_data(
-        ("liam", roles.LIBRARY_AUTHOR.external_key, 3),
-        ("eve", roles.LIBRARY_ADMIN.external_key, 1),
-        ("eve", roles.LIBRARY_AUTHOR.external_key, 1),
-        ("eve", roles.LIBRARY_USER.external_key, 1),
-        ("alice", roles.LIBRARY_AUTHOR.external_key, 0),
-        ("non_existent_user", roles.LIBRARY_ADMIN.external_key, 0),
-    )
-    @unpack
-    def test_get_subject_role_assignments_for_role(self, subject_name, role_name, expected_count):
-        """Test retrieving role assignments for a subject filtered by role across all scopes."""
-        role_assignments = get_subject_role_assignments_for_role(
-            SubjectData(external_key=subject_name),
-            RoleData(external_key=role_name),
-        )
-        self.assertEqual(len(role_assignments), expected_count)
 
     @ddt_data(
         (roles.LIBRARY_ADMIN.external_key, "lib:Org1:math_101", 1),

--- a/openedx_authz/tests/api/test_roles.py
+++ b/openedx_authz/tests/api/test_roles.py
@@ -21,13 +21,16 @@ from openedx_authz.api.data import (
     RoleData,
     ScopeData,
     SubjectData,
+    UserData,
 )
 from openedx_authz.api.roles import (
+    _get_field_index_and_values,
     assign_role_to_subject_in_scope,
     batch_assign_role_to_subjects_in_scope,
     get_all_subject_role_assignments_in_scope,
     get_permissions_for_active_roles_in_scope,
     get_permissions_for_single_role,
+    get_role_assignments,
     get_role_definitions_in_scope,
     get_scopes_for_subject_and_permission,
     get_subject_role_assignments,
@@ -333,6 +336,17 @@ class RolesTestSetupMixin(BaseRolesTestCase):
                 "subject_name": "frank",
                 "role_name": roles.LIBRARY_USER.external_key,
                 "scope_name": "lib:Org6:project_epsilon",
+            },
+            # Same user, same scope, different role
+            {
+                "subject_name": "george",
+                "role_name": roles.LIBRARY_AUTHOR.external_key,
+                "scope_name": "lib:Org6:project_zeta",
+            },
+            {
+                "subject_name": "george",
+                "role_name": roles.LIBRARY_CONTRIBUTOR.external_key,
+                "scope_name": "lib:Org6:project_zeta",
             },
         ]
         cls._assign_roles_to_users(assignments=assignments)
@@ -641,6 +655,99 @@ class TestRolesAPI(RolesTestSetupMixin):
         )
 
         self.assertEqual(len(role_assignments), expected_count)
+
+    @ddt_data(
+        # Test with subject only
+        ("alice", None, None, 1),
+        ("eve", None, None, 3),
+        # Test with role only
+        (None, roles.LIBRARY_ADMIN.external_key, None, 5),
+        (None, roles.LIBRARY_AUTHOR.external_key, None, 8),
+        (None, roles.LIBRARY_CONTRIBUTOR.external_key, None, 6),
+        (None, roles.LIBRARY_USER.external_key, None, 6),
+        (None, roles.COURSE_STAFF.external_key, None, 7),
+        # Test with scope only
+        (None, None, "lib:Org1:math_101", 1),
+        (None, None, "lib:Org1:history_201", 1),
+        (None, None, "lib:Org1:science_301", 1),
+        (None, None, "lib:Org1:english_101", 1),
+        (None, None, "lib:Org1:math_advanced", 2),
+        # Test with subject and scope
+        ("alice", None, "lib:Org1:math_101", 1),
+        ("bob", None, "lib:Org1:history_201", 1),
+        ("carol", None, "lib:Org1:science_301", 1),
+        ("george", None, "lib:Org6:project_zeta", 2),
+        # Test with subject and role
+        ("daniel", roles.COURSE_STAFF.external_key, None, 1),
+        ("liam", roles.LIBRARY_AUTHOR.external_key, None, 3),
+        ("carlos", roles.COURSE_STAFF.external_key, None, 3),
+        # Test with role and scope
+        (None, roles.LIBRARY_CONTRIBUTOR.external_key, "lib:Org1:math_advanced", 2),
+        (None, roles.LIBRARY_ADMIN.external_key, "lib:Org5:economics_101", 1),
+        (None, roles.LIBRARY_CONTRIBUTOR.external_key, "lib:Org5:economics_101", 1),
+        (None, roles.LIBRARY_USER.external_key, "lib:Org5:economics_101", 1),
+        # Test with subject, role, and scope
+        ("ivy", roles.LIBRARY_ADMIN.external_key, "lib:Org3:cs_101", 1),
+        ("jack", roles.LIBRARY_AUTHOR.external_key, "lib:Org3:cs_101", 1),
+        ("kate", roles.LIBRARY_USER.external_key, "lib:Org3:cs_101", 1),
+        ("peter", roles.LIBRARY_ADMIN.external_key, "lib:Org6:project_alpha", 1),
+        ("peter", roles.LIBRARY_AUTHOR.external_key, "lib:Org6:project_beta", 1),
+        ("peter", roles.LIBRARY_CONTRIBUTOR.external_key, "lib:Org6:project_gamma", 1),
+        ("peter", roles.LIBRARY_USER.external_key, "lib:Org6:project_delta", 1),
+        # Edge cases - non-existent entities
+        ("non_existent_user", None, "lib:Org1:math_101", 0),
+        ("alice", None, "lib:Org999:non_existent_scope", 0),
+        ("non_existent_user", None, "lib:Org999:non_existent_scope", 0),
+        (None, "non_existent_role", "lib:Org1:math_101", 0),
+        ("alice", "non_existent_role", "lib:Org1:math_101", 0),
+        ("non_existent_user", "non_existent_role", "lib:Org999:non_existent_scope", 0),
+    )
+    @unpack
+    def test_get_role_assignments_with_filters(self, subject_name, role_name, scope_name, expected_count):
+        """Test get_role_assignments with flexible subject/role/scope filtering.
+
+        This test demonstrates that get_role_assignments supports multiple filtering modes:
+        - Filter by subject only: Get all role assignments across all scopes for a user
+        - Filter by role only: Get all assignments for a specific role across all scopes
+        - Filter by scope only: Get all role assignments within a specific scope
+        - Filter by subject and scope: Equivalent to get_subject_role_assignments_in_scope
+        - Filter by subject and role: Get assignments for a user with a specific role
+        - Filter by role and scope: Find all subjects with a specific role in a scope
+        - Filter by all three: Precise queries for a specific subject-role-scope combination
+        - Handle non-existent entities gracefully: Returns empty list for invalid filters
+
+        Expected result:
+            - Returns correct number of role assignments based on the filters provided
+            - Each assignment matches all specified filters
+            - Returns empty list for non-existent entities
+        """
+        subject = SubjectData(external_key=subject_name) if subject_name else None
+        role = RoleData(external_key=role_name) if role_name else None
+        scope = ScopeData(external_key=scope_name) if scope_name else None
+
+        role_assignments = get_role_assignments(subject=subject, role=role, scope=scope)
+
+        self.assertEqual(len(role_assignments), expected_count)
+
+        # Ensure all assignments match the filters
+        for assignment in role_assignments:
+            if subject_name:
+                self.assertEqual(
+                    assignment.subject.external_key,
+                    subject_name,
+                    f"Expected subject {subject_name}, got {assignment.subject.external_key}",
+                )
+            if role_name:
+                self.assertTrue(
+                    any(r.external_key == role_name for r in assignment.roles),
+                    f"Expected role {role_name} not found in assignment",
+                )
+            if scope_name:
+                self.assertEqual(
+                    assignment.scope.external_key,
+                    scope_name,
+                    f"Expected scope {scope_name}, got {assignment.scope.external_key}",
+                )
 
     @ddt_data(
         # Test case: alice with 'view_library' permission (has library_admin in math_101)
@@ -1181,3 +1288,142 @@ class TestRoleAssignmentAPI(RolesTestSetupMixin):
 
         new_roles = {r.external_key for assignment in new_assignments for r in assignment.roles}
         self.assertIn("library_admin", new_roles)
+
+
+@ddt
+class TestFieldIndexAndValues(TestCase):
+    """Test cases for _get_field_index_and_values helper function.
+
+    This function builds field index and values for Casbin's get_filtered_grouping_policy.
+    It determines the leftmost non-None field as field_index and returns consecutive values
+    from that position, using empty strings as wildcards for gaps.
+    """
+
+    @ddt_data(
+        # All None
+        (None, None, None, 0, []),
+        # All three parameters provided
+        (
+            UserData(external_key="steve"),
+            RoleData(external_key="course_admin"),
+            ScopeData(external_key="course-v1:OpenedX+Demo+Course"),
+            0,
+            [
+                "user^steve",
+                "role^course_admin",
+                "course-v1^course-v1:OpenedX+Demo+Course",
+            ],
+        ),
+        # Only subject provided
+        (
+            UserData(external_key="steve"),
+            None,
+            None,
+            0,
+            ["user^steve"],
+        ),
+        # Subject and role provided (no scope)
+        (
+            UserData(external_key="steve"),
+            RoleData(external_key="course_admin"),
+            None,
+            0,
+            ["user^steve", "role^course_admin"],
+        ),
+        # Only role provided (subject is None)
+        (None, RoleData(external_key="course_admin"), None, 1, ["role^course_admin"]),
+        # Role and scope provided (subject is None)
+        (
+            None,
+            RoleData(external_key="course_admin"),
+            ScopeData(external_key="course-v1:OpenedX+Demo+Course"),
+            1,
+            ["role^course_admin", "course-v1^course-v1:OpenedX+Demo+Course"],
+        ),
+        # Only scope provided (subject and role are None)
+        (
+            None,
+            None,
+            ScopeData(external_key="course-v1:OpenedX+Demo+Course"),
+            2,
+            ["course-v1^course-v1:OpenedX+Demo+Course"],
+        ),
+        # Subject and scope provided (role is None - creates gap)
+        (
+            UserData(external_key="steve"),
+            None,
+            ScopeData(external_key="course-v1:OpenedX+Demo+Course"),
+            0,
+            ["user^steve", "", "course-v1^course-v1:OpenedX+Demo+Course"],
+        ),
+        # Library-related examples
+        (
+            UserData(external_key="alice"),
+            RoleData(external_key="library_admin"),
+            ScopeData(external_key="lib:Org1:math_101"),
+            0,
+            ["user^alice", "role^library_admin", "lib^lib:Org1:math_101"],
+        ),
+        (
+            None,
+            RoleData(external_key="library_user"),
+            ScopeData(external_key="lib:Org2:science_101"),
+            1,
+            ["role^library_user", "lib^lib:Org2:science_101"],
+        ),
+    )
+    @unpack
+    def test_get_field_index_and_values(
+        self,
+        subject,
+        role,
+        scope,
+        expected_index,
+        expected_values,
+    ):  # pylint: disable=too-many-positional-arguments
+        """Test that _get_field_index_and_values correctly builds field index and values.
+
+        Expected result:
+            - Returns the correct field_index (leftmost non-None parameter position)
+            - Returns consecutive values from that index
+            - Empty strings serve as wildcards for gaps
+            - Trailing empty strings are removed
+        """
+        field_index, field_values = _get_field_index_and_values(subject, role, scope)
+
+        self.assertEqual(field_index, expected_index)
+        self.assertEqual(field_values, expected_values)
+
+    def test_get_field_index_and_values_removes_trailing_wildcards(self):
+        """Test that trailing empty strings are removed from field_values.
+
+        Expected result:
+            - When the last parameters are None, they don't appear as empty strings
+            - Only intermediate gaps appear as empty strings
+        """
+        subject = UserData(external_key="john")
+        role = RoleData(external_key="instructor")
+        scope = None
+
+        field_index, field_values = _get_field_index_and_values(subject, role, scope)
+
+        self.assertEqual(field_index, 0)
+        self.assertEqual(field_values, ["user^john", "role^instructor"])
+        self.assertNotEqual(field_values[-1], "")
+
+    def test_get_field_index_and_values_preserves_intermediate_wildcards(self):
+        """Test that intermediate gaps are preserved as empty strings.
+
+        Expected result:
+            - When middle parameter is None but first and last are provided,
+              an empty string appears in the middle of the list
+        """
+        subject = UserData(external_key="mary")
+        role = None
+        scope = ScopeData(external_key="lib:Org3:history_201")
+
+        field_index, field_values = _get_field_index_and_values(subject, role, scope)
+
+        self.assertEqual(field_index, 0)
+        self.assertEqual(field_values, ["user^mary", "", "lib^lib:Org3:history_201"])
+        self.assertEqual(field_values[1], "")

--- a/openedx_authz/tests/api/test_users.py
+++ b/openedx_authz/tests/api/test_users.py
@@ -9,6 +9,7 @@ from openedx_authz.api.users import (
     batch_unassign_role_from_users,
     get_all_user_role_assignments_in_scope,
     get_user_role_assignments,
+    get_user_role_assignments_for_role,
     get_user_role_assignments_for_role_in_scope,
     get_user_role_assignments_in_scope,
     is_user_allowed,
@@ -51,6 +52,39 @@ class UserAssignmentsSetupMixin(RolesTestSetupMixin):
 @ddt
 class TestUserRoleAssignments(UserAssignmentsSetupMixin):
     """Test suite for user-role assignment API functions."""
+
+    @data(
+        ("alice", roles.LIBRARY_ADMIN.external_key, 1, {"lib:Org1:math_101"}),
+        ("eve", roles.LIBRARY_ADMIN.external_key, 1, {"lib:Org2:physics_401"}),
+        (
+            "liam",
+            roles.LIBRARY_AUTHOR.external_key,
+            3,
+            {"lib:Org4:art_101", "lib:Org4:art_201", "lib:Org4:art_301"},
+        ),
+        ("alice", roles.LIBRARY_AUTHOR.external_key, 0, set()),
+        ("non_existent_user", roles.LIBRARY_ADMIN.external_key, 0, set()),
+    )
+    @unpack
+    def test_get_user_role_assignments_for_role(
+        self,
+        username,
+        role_external_key,
+        expected_count,
+        expected_scopes,
+    ):
+        role_assignments = get_user_role_assignments_for_role(
+            user_external_key=username,
+            role_external_key=role_external_key,
+        )
+
+        self.assertEqual(len(role_assignments), expected_count)
+
+        role_names = {r.external_key for assignment in role_assignments for r in assignment.roles}
+        self.assertEqual(role_names, set() if expected_count == 0 else {role_external_key})
+
+        scopes = {assignment.scope.external_key for assignment in role_assignments}
+        self.assertEqual(scopes, expected_scopes)
 
     @data(
         ("john", roles.LIBRARY_ADMIN.external_key, "lib:Org1:math_101", False),

--- a/openedx_authz/tests/api/test_users.py
+++ b/openedx_authz/tests/api/test_users.py
@@ -9,7 +9,6 @@ from openedx_authz.api.users import (
     batch_unassign_role_from_users,
     get_all_user_role_assignments_in_scope,
     get_user_role_assignments,
-    get_user_role_assignments_for_role,
     get_user_role_assignments_for_role_in_scope,
     get_user_role_assignments_in_scope,
     is_user_allowed,
@@ -52,39 +51,6 @@ class UserAssignmentsSetupMixin(RolesTestSetupMixin):
 @ddt
 class TestUserRoleAssignments(UserAssignmentsSetupMixin):
     """Test suite for user-role assignment API functions."""
-
-    @data(
-        ("alice", roles.LIBRARY_ADMIN.external_key, 1, {"lib:Org1:math_101"}),
-        ("eve", roles.LIBRARY_ADMIN.external_key, 1, {"lib:Org2:physics_401"}),
-        (
-            "liam",
-            roles.LIBRARY_AUTHOR.external_key,
-            3,
-            {"lib:Org4:art_101", "lib:Org4:art_201", "lib:Org4:art_301"},
-        ),
-        ("alice", roles.LIBRARY_AUTHOR.external_key, 0, set()),
-        ("non_existent_user", roles.LIBRARY_ADMIN.external_key, 0, set()),
-    )
-    @unpack
-    def test_get_user_role_assignments_for_role(
-        self,
-        username,
-        role_external_key,
-        expected_count,
-        expected_scopes,
-    ):
-        role_assignments = get_user_role_assignments_for_role(
-            user_external_key=username,
-            role_external_key=role_external_key,
-        )
-
-        self.assertEqual(len(role_assignments), expected_count)
-
-        role_names = {r.external_key for assignment in role_assignments for r in assignment.roles}
-        self.assertEqual(role_names, set() if expected_count == 0 else {role_external_key})
-
-        scopes = {assignment.scope.external_key for assignment in role_assignments}
-        self.assertEqual(scopes, expected_scopes)
 
     @data(
         ("john", roles.LIBRARY_ADMIN.external_key, "lib:Org1:math_101", False),


### PR DESCRIPTION
## Description

This PR creates a new api function: `get_user_role_assignments_filtered` to fetch a subject's role assignments filtered by user,  role, and/or scope.

Additionally, it adds the `org` property to `ContentLibraryData` and `CourseOverviewData`. This is necessary to get the specific **organization** for each scope's data, not only for glob scopes.

## Related Issues

- https://github.com/openedx/openedx-platform/issues/38032

## Testing Instructions

1. Add different roles to a user in different scopes.
2. Now, use the `get_user_role_assignments_filtered` function:

```python
from openedx_authz.api import assign_role_to_user_in_scope, get_user_role_assignments_filtered

assign_role_to_user_in_scope("marie", "course_staff", "course-v1:OpenedX+DemoX+DemoCourse")
assign_role_to_user_in_scope("marie", "course_staff", "course-v1:WGU+Python+2020")
assign_role_to_user_in_scope("marie", "course_staff", "course-v1:OpenedX+RBAC+2026")
assign_role_to_user_in_scope("marie", "course_auditor", "course-v1:XBlocks.org+XBlocks+2026")
assign_role_to_user_in_scope("marie", "course_auditor", "course-v1:WGUv2+Python+2025")
assign_role_to_user_in_scope("marie", "course_auditor", "course-v1:AXIM+*")

>>> get_user_role_assignments_filtered(user_external_key="marie", role_external_key="course_staff")
[
    user^marie => [role^course_staff] @ course-v1^course-v1:OpenedX+DemoX+DemoCourse,
    user^marie => [role^course_staff] @ course-v1^course-v1:WGU+AdvancedPython+2026,
    user^marie => [role^course_staff] @ course-v1^course-v1:OpenedX+RBAC+2026,
]

>>> get_user_role_assignments_filtered(user_external_key="marie", role_external_key="course_auditor") 
[
    user^marie => [role^course_auditor] @ course-v1^course-v1:XBlocks.org+XBlocks+2026,
    user^marie => [role^course_auditor] @ course-v1^course-v1:WGUv2+Python+2025,
    user^marie => [role^course_auditor] @ course-v1^course-v1:AXIM+*
]
```

## Merge checklist

Check off if complete *or* not applicable:
- [x] Version bumped
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Fixup commits are squashed away
- [x] Unit tests added/updated
- [x] Manual testing instructions provided
- [x] Noted any: Concerns, dependencies, migration issues, deadlines, tickets
