### PR TITLE
Add CCX concepts, fix errors around CCX

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         python-version: ["3.12"]
-        toxenv: [quality, docs, pii_check, django42, django52]
+        toxenv: [quality, docs, pii_check, django52]
     steps:
       - uses: actions/checkout@v6
       - name: setup python
@@ -35,7 +35,7 @@ jobs:
         run: tox
 
       - name: Run coverage
-        if: matrix.python-version == '3.12' && matrix.toxenv == 'django42'
+        if: matrix.python-version == '3.12' && matrix.toxenv == 'django52'
         uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,10 @@ Change Log
 Unreleased
 **********
 
+1.3.0 2026-04-08
+****************
+
+* Add stub CCX_COACH role/ CCXCourseOverviewData scope to prevent errors when working with CCX courses.
 * Add ADR for global scope support for role assignments.
 
 1.2.0 - 2026-03-30

--- a/openedx_authz/__init__.py
+++ b/openedx_authz/__init__.py
@@ -4,6 +4,6 @@ Open edX AuthZ provides the architecture and foundations of the authorization fr
 
 import os
 
-__version__ = "1.2.0"
+__version__ = "1.3.0"
 
 ROOT_DIRECTORY = os.path.dirname(os.path.abspath(__file__))

--- a/openedx_authz/api/data.py
+++ b/openedx_authz/api/data.py
@@ -843,7 +843,7 @@ class OrgCourseOverviewGlobData(OrgGlobData):
 class CCXCourseOverviewData(CourseOverviewData):
     """CCX course scope for authorization in the Open edX platform.
 
-    Inherits from CourseOverviewData as CCXs are coursees, just in a different namespace.
+    Inherits from CourseOverviewData as CCXs are courses, just in a different namespace.
 
     Attributes:
         NAMESPACE: 'ccx-v1' for course scopes.
@@ -853,7 +853,7 @@ class CCXCourseOverviewData(CourseOverviewData):
         course_id: Property alias for external_key.
 
     Examples:
-        >>> course = CourseOverviewData(external_key='ccx-v1:OpenedX+DemoX+DemoCourse+ccx@1')
+        >>> course = CCXCourseOverviewData(external_key='ccx-v1:OpenedX+DemoX+DemoCourse+ccx@1')
         >>> course.namespaced_key
         'ccx-v1^ccx-v1:OpenedX+DemoX+DemoCourse+ccx@1'
         >>> course.course_id

--- a/openedx_authz/api/data.py
+++ b/openedx_authz/api/data.py
@@ -838,8 +838,8 @@ class OrgCourseOverviewGlobData(OrgGlobData):
 
     NAMESPACE: ClassVar[str] = "course-v1"
     ID_SEPARATOR: ClassVar[str] = "+"
-    
-    
+
+
 class CCXCourseOverviewData(CourseOverviewData):
     """CCX course scope for authorization in the Open edX platform.
 

--- a/openedx_authz/api/data.py
+++ b/openedx_authz/api/data.py
@@ -838,6 +838,30 @@ class OrgCourseOverviewGlobData(OrgGlobData):
 
     NAMESPACE: ClassVar[str] = "course-v1"
     ID_SEPARATOR: ClassVar[str] = "+"
+    
+    
+class CCXCourseOverviewData(CourseOverviewData):
+    """CCX course scope for authorization in the Open edX platform.
+
+    Inherits from CourseOverviewData as CCXs are coursees, just in a different namespace.
+
+    Attributes:
+        NAMESPACE: 'ccx-v1' for course scopes.
+        external_key: The course identifier (e.g., 'ccx-v1:OpenedX+DemoX+DemoCourse+ccx@1').
+            Must be a valid CourseKey format.
+        namespaced_key: The course identifier with namespace (e.g., 'ccx-v1^ccx-v1:OpenedX+DemoX+DemoCourse+ccx@1').
+        course_id: Property alias for external_key.
+
+    Examples:
+        >>> course = CourseOverviewData(external_key='ccx-v1:OpenedX+DemoX+DemoCourse+ccx@1')
+        >>> course.namespaced_key
+        'ccx-v1^ccx-v1:OpenedX+DemoX+DemoCourse+ccx@1'
+        >>> course.course_id
+        'ccx-v1:OpenedX+DemoX+DemoCourse+ccx@1'
+
+    """
+
+    NAMESPACE: ClassVar[str] = "ccx-v1"
 
 
 class SubjectMeta(type):

--- a/openedx_authz/constants/roles.py
+++ b/openedx_authz/constants/roles.py
@@ -181,7 +181,7 @@ COURSE_BETA_TESTER_PERMISSIONS = [
 COURSE_BETA_TESTER = RoleData(external_key="course_beta_tester", permissions=COURSE_BETA_TESTER_PERMISSIONS)
 
 # This is a known LMS-only permission, but doesn't actually grant anything yet.
-# 
+#
 # It is intended to be handled in the Willow time frame.
 CCX_COACH_PERMISSIONS = []
 CCX_COACH = RoleData(external_key="ccx_coach", permissions=CCX_COACH_PERMISSIONS)

--- a/openedx_authz/constants/roles.py
+++ b/openedx_authz/constants/roles.py
@@ -180,6 +180,13 @@ COURSE_BETA_TESTER_PERMISSIONS = [
 
 COURSE_BETA_TESTER = RoleData(external_key="course_beta_tester", permissions=COURSE_BETA_TESTER_PERMISSIONS)
 
+# This is a known LMS-only permission, but doesn't actually grant anything yet.
+# 
+# It is intended to be handled in the Willow time frame.
+CCX_COACH_PERMISSIONS = []
+CCX_COACH = RoleData(external_key="ccx_coach", permissions=CCX_COACH_PERMISSIONS)
+
+
 # Map of legacy course role names to their equivalent new roles
 # This mapping must be unique in both directions, since it may be used as a reverse lookup (value → key).
 # If multiple keys share the same value, it will lead to collisions.
@@ -189,4 +196,5 @@ LEGACY_COURSE_ROLE_EQUIVALENCES = {
     "limited_staff": COURSE_LIMITED_STAFF.external_key,
     "data_researcher": COURSE_DATA_RESEARCHER.external_key,
     "beta_testers": COURSE_BETA_TESTER.external_key,
+    "ccx_coach": CCX_COACH.external_key,
 }

--- a/openedx_authz/engine/utils.py
+++ b/openedx_authz/engine/utils.py
@@ -258,7 +258,8 @@ def migrate_legacy_course_roles_to_authz(course_access_role_model, course_id_lis
         if not is_user_added:
             logger.error(
                 f"Failed to migrate permission for User: {permission.user.username} "
-                f"to Role: {role} in Scope: {permission.course_id}"
+                f"to Role: {role} in Scope: {permission.course_id} "
+                "user may already have this permission assigned"
             )
             permissions_with_errors.append(permission)
             continue

--- a/openedx_authz/engine/utils.py
+++ b/openedx_authz/engine/utils.py
@@ -178,7 +178,7 @@ def _validate_migration_input(course_id_list, org_id):
             "At least one of course_id_list or org_id must be provided to limit the scope of the migration."
         )
 
-    if course_id_list and any([course_key for course_key in course_id_list if not course_key.startswith("course-v1:")]):
+    if course_id_list and any(not course_key.startswith("course-v1:") for course_key in course_id_list):
         raise ValueError(
             "Only full course keys (e.g., 'course-v1:org+course+run') are supported in the course_id_list."
             " Other course types such as CCX are not supported."

--- a/openedx_authz/engine/utils.py
+++ b/openedx_authz/engine/utils.py
@@ -169,6 +169,22 @@ def migrate_legacy_permissions(ContentLibraryPermission):
     return permissions_with_errors
 
 
+def _validate_migration_input(course_id_list, org_id):
+    """
+    Validate the common inputs for the migration functions.
+    """
+    if not course_id_list and not org_id:
+        raise ValueError(
+            "At least one of course_id_list or org_id must be provided to limit the scope of the migration."
+        )
+
+    if course_id_list and any([course_key for course_key in course_id_list if not course_key.startswith("course-v1:")]):
+        raise ValueError(
+            "Only full course keys (e.g., 'course-v1:org+course+run') are supported in the course_id_list."
+            " Other course types such as CCX are not supported."
+        )
+
+
 def migrate_legacy_course_roles_to_authz(course_access_role_model, course_id_list, org_id, delete_after_migration):
     """
     Migrate legacy course role data to the new Casbin-based authorization model.
@@ -194,10 +210,8 @@ def migrate_legacy_course_roles_to_authz(course_access_role_model, course_id_lis
     param org_id: Optional organization ID to filter the migration.
     param delete_after_migration: Whether to delete successfully migrated legacy permissions after migration.
     """
-    if not course_id_list and not org_id:
-        raise ValueError(
-            "At least one of course_id_list or org_id must be provided to limit the scope of the migration."
-        )
+    _validate_migration_input(course_id_list, org_id)
+
     course_access_role_filter = {
         "course_id__startswith": "course-v1:",
     }
@@ -280,10 +294,7 @@ def migrate_authz_to_legacy_course_roles(
     param delete_after_migration: Whether to unassign successfully migrated permissions
     from the new model after migration.
     """
-    if not course_id_list and not org_id:
-        raise ValueError(
-            "At least one of course_id_list or org_id must be provided to limit the scope of the rollback migration."
-        )
+    _validate_migration_input(course_id_list, org_id)
 
     # 1. Get all users with course-related permissions in the new model by filtering
     # UserSubjects that are linked to CourseScopes with a valid course overview.

--- a/openedx_authz/management/commands/authz_migrate_course_authoring.py
+++ b/openedx_authz/management/commands/authz_migrate_course_authoring.py
@@ -86,7 +86,7 @@ class Command(BaseCommand):
                     self.stdout.write(
                         self.style.ERROR(
                             "No legacy roles found for the given scope, course could already be migrated, "
-                            "or there coule be a an error in the course_id_list / org_id."
+                            "or there could be an error in the course_id_list / org_id."
                         )
                     )
 

--- a/openedx_authz/management/commands/authz_migrate_course_authoring.py
+++ b/openedx_authz/management/commands/authz_migrate_course_authoring.py
@@ -70,11 +70,24 @@ class Command(BaseCommand):
                     delete_after_migration=delete_after_migration,
                 )
 
-                if errors:
+                if errors and success:
+                    self.stdout.write(
+                        self.style.WARNING(
+                            f"Migration completed with {len(errors)} errors and {len(success)} roles migrated."
+                        )
+                    )
+                elif errors:
                     self.stdout.write(self.style.ERROR(f"Migration completed with {len(errors)} errors."))
-                else:
+                elif success:
                     self.stdout.write(
                         self.style.SUCCESS(f"Migration completed successfully with {len(success)} roles migrated.")
+                    )
+                else:
+                    self.stdout.write(
+                        self.style.ERROR(
+                            "No legacy roles found for the given scope, course could already be migrated, "
+                            "or there coule be a an error in the course_id_list / org_id."
+                        )
                     )
 
                 if delete_after_migration:

--- a/openedx_authz/management/commands/authz_rollback_course_authoring.py
+++ b/openedx_authz/management/commands/authz_rollback_course_authoring.py
@@ -74,11 +74,24 @@ class Command(BaseCommand):
                     delete_after_migration=delete_after_migration,  # control deletion here
                 )
 
-                if errors:
+                if errors and success:
+                    self.stdout.write(
+                        self.style.WARNING(
+                            f"Rollback completed with {len(errors)} errors and {len(success)} roles migrated."
+                        )
+                    )
+                elif errors:
                     self.stdout.write(self.style.ERROR(f"Rollback completed with {len(errors)} errors."))
-                else:
+                elif success:
                     self.stdout.write(
                         self.style.SUCCESS(f"Rollback completed successfully with {len(success)} roles rolled back.")
+                    )
+                else:
+                    self.stdout.write(
+                        self.style.ERROR(
+                            "No roles found for the given scope, course could already be rolled back, "
+                            "or there coule be a an error in the course_id_list / org_id."
+                        )
                     )
 
                 if delete_after_migration:

--- a/openedx_authz/management/commands/authz_rollback_course_authoring.py
+++ b/openedx_authz/management/commands/authz_rollback_course_authoring.py
@@ -77,7 +77,7 @@ class Command(BaseCommand):
                 if errors and success:
                     self.stdout.write(
                         self.style.WARNING(
-                            f"Rollback completed with {len(errors)} errors and {len(success)} roles migrated."
+                            f"Rollback completed with {len(errors)} errors and {len(success)} roles rolled back."
                         )
                     )
                 elif errors:
@@ -90,7 +90,7 @@ class Command(BaseCommand):
                     self.stdout.write(
                         self.style.ERROR(
                             "No roles found for the given scope, course could already be rolled back, "
-                            "or there coule be a an error in the course_id_list / org_id."
+                            "or there could be an error in the course_id_list / org_id."
                         )
                     )
 

--- a/openedx_authz/tests/api/test_data.py
+++ b/openedx_authz/tests/api/test_data.py
@@ -8,6 +8,7 @@ from opaque_keys.edx.locator import LibraryLocatorV2
 
 from openedx_authz.api.data import (
     ActionData,
+    CCXCourseOverviewData,
     ContentLibraryData,
     CourseOverviewData,
     OrgContentLibraryGlobData,
@@ -257,6 +258,8 @@ class TestScopeMetaClass(TestCase):
         self.assertIs(ScopeData.scope_registry["lib"], ContentLibraryData)
         self.assertIn("course-v1", ScopeData.scope_registry)
         self.assertIs(ScopeData.scope_registry["course-v1"], CourseOverviewData)
+        self.assertIn("ccx-v1", ScopeData.scope_registry)
+        self.assertIs(ScopeData.scope_registry["ccx-v1"], CCXCourseOverviewData)
 
         # Glob registries for organization-level scopes
         self.assertIn("lib", ScopeMeta.glob_registry)
@@ -265,6 +268,7 @@ class TestScopeMetaClass(TestCase):
         self.assertIs(ScopeMeta.glob_registry["course-v1"], OrgCourseOverviewGlobData)
 
     @data(
+        ("ccx-v1^ccx-v1:OpenedX+DemoX+DemoCourse+ccx@1", CCXCourseOverviewData),
         ("course-v1^course-v1:WGU+CS002+2025_T1", CourseOverviewData),
         ("lib^lib:DemoX:CSPROB", ContentLibraryData),
         ("lib^lib:DemoX*", OrgContentLibraryGlobData),
@@ -285,6 +289,7 @@ class TestScopeMetaClass(TestCase):
         self.assertEqual(instance.namespaced_key, namespaced_key)
 
     @data(
+        ("ccx-v1^ccx-v1:OpenedX+DemoX+DemoCourse+ccx@1", CCXCourseOverviewData),
         ("course-v1^course-v1:WGU+CS002+2025_T1", CourseOverviewData),
         ("lib^lib:DemoX:CSPROB", ContentLibraryData),
         ("lib^lib:DemoX:*", OrgContentLibraryGlobData),
@@ -297,6 +302,8 @@ class TestScopeMetaClass(TestCase):
         """Test get_subclass_by_namespaced_key returns correct subclass.
 
         Expected Result:
+            - 'ccx-v1^...' returns CCXCourseOverviewData
+            - 'course-v1^...' returns CourseOverviewData
             - 'lib^...' returns ContentLibraryData
             - 'global^...' returns ScopeData
             - 'unknown^...' returns ScopeData (fallback)
@@ -306,6 +313,7 @@ class TestScopeMetaClass(TestCase):
         self.assertIs(subclass, expected_class)
 
     @data(
+        ("ccx-v1:OpenedX+DemoX+DemoCourse+ccx@1", CCXCourseOverviewData),
         ("course-v1:WGU+CS002+2025_T1", CourseOverviewData),
         ("lib:DemoX:CSPROB", ContentLibraryData),
         ("lib:DemoX:*", OrgContentLibraryGlobData),
@@ -326,6 +334,11 @@ class TestScopeMetaClass(TestCase):
         self.assertIs(subclass, expected_class)
 
     @data(
+        ("ccx-v1:OpenedX+DemoX+DemoCourse+ccx@1", True, CCXCourseOverviewData),
+        ("ccx:OpenedX+DemoX+DemoCourse+ccx@1", False, CCXCourseOverviewData),
+        ("ccx-v2:OpenedX+DemoX+DemoCourse+ccx@1", False, CCXCourseOverviewData),
+        ("ccx-v1-OpenedX+DemoX+DemoCourse+ccx@1", False, CCXCourseOverviewData),
+        ("ccx-v1-OpenedX+DemoX+DemoCourse+ccx", False, CCXCourseOverviewData),
         ("course-v1:WGU+CS002+2025_T1", True, CourseOverviewData),
         ("course:WGU+CS002+2025_T1", False, CourseOverviewData),
         ("course-v2:WGU+CS002+2025_T1", False, CourseOverviewData),

--- a/openedx_authz/tests/test_migrations.py
+++ b/openedx_authz/tests/test_migrations.py
@@ -942,6 +942,51 @@ class TestLegacyCourseAuthoringPermissionsMigration(TestCase):
 
         self.assertEqual(kwargs["delete_after_migration"], True)
 
+    @patch("openedx_authz.management.commands.authz_migrate_course_authoring.CourseAccessRole", CourseAccessRole)
+    @patch("openedx_authz.management.commands.authz_migrate_course_authoring.migrate_legacy_course_roles_to_authz")
+    def test_authz_migrate_course_authoring_command_mixed_success(self, mock_migrate):
+        """
+        Verify that the authz_migrate_course_authoring command outputs without errors
+        for mixed success operations.
+        """
+
+        mock_migrate.return_value = (
+            ["course-v1:fail"],
+            [self.course_id],
+        )  # Return one success and one failure
+
+        call_command("authz_migrate_course_authoring", "--course-id-list", self.course_id)
+        mock_migrate.assert_called_once()
+
+        # Return only one success
+        mock_migrate.reset_mock()
+        mock_migrate.return_value = (
+            [],
+            [self.course_id],
+        )
+
+        call_command("authz_migrate_course_authoring", "--course-id-list", self.course_id)
+        mock_migrate.assert_called_once()
+
+        # Return only one failure
+        mock_migrate.reset_mock()
+        mock_migrate.return_value = (
+            [self.course_id],
+            [],
+        )
+
+        call_command("authz_migrate_course_authoring", "--course-id-list", self.course_id)
+        mock_migrate.assert_called_once()
+
+        # Return only no successes or failures
+        mock_migrate.reset_mock()
+        mock_migrate.return_value = (
+            [],
+            [],
+        )
+        call_command("authz_migrate_course_authoring", "--course-id-list", self.course_id)
+        mock_migrate.assert_called_once()
+
     @patch("openedx_authz.management.commands.authz_rollback_course_authoring.CourseAccessRole", CourseAccessRole)
     @patch("openedx_authz.management.commands.authz_rollback_course_authoring.migrate_authz_to_legacy_course_roles")
     def test_authz_rollback_course_authoring_command(self, mock_rollback):
@@ -971,6 +1016,52 @@ class TestLegacyCourseAuthoringPermissionsMigration(TestCase):
         call_kwargs = mock_rollback.call_args_list[0][1]
 
         self.assertEqual(call_kwargs["delete_after_migration"], True)
+
+    @patch("openedx_authz.management.commands.authz_rollback_course_authoring.CourseAccessRole", CourseAccessRole)
+    @patch("openedx_authz.management.commands.authz_rollback_course_authoring.migrate_authz_to_legacy_course_roles")
+    def test_authz_rollback_course_authoring_command_mixed_success(self, mock_rollback):
+        """
+        Verify that the authz_rollback_course_authoring command does not error in
+        mixed success operations.
+        """
+
+        # Return one success and one failure
+        mock_rollback.return_value = (
+            ["course-v1:fail"],
+            [self.course_id],
+        )
+        call_command("authz_rollback_course_authoring", "--course-id-list", self.course_id)
+        mock_rollback.assert_called_once()
+
+        # Return only one success
+        mock_rollback.reset_mock()
+        mock_rollback.return_value = (
+            [],
+            [self.course_id],
+        )
+
+        call_command("authz_rollback_course_authoring", "--course-id-list", self.course_id)
+        mock_rollback.assert_called_once()
+
+        # Return only one failure
+        mock_rollback.reset_mock()
+        mock_rollback.return_value = (
+            [self.course_id],
+            [],
+        )
+
+        call_command("authz_rollback_course_authoring", "--course-id-list", self.course_id)
+        mock_rollback.assert_called_once()
+
+        # Return only no successes or failures
+        mock_rollback.reset_mock()
+        mock_rollback.return_value = (
+            [],
+            [],
+        )
+
+        call_command("authz_rollback_course_authoring", "--course-id-list", self.course_id)
+        mock_rollback.assert_called_once()
 
     @patch("openedx_authz.management.commands.authz_migrate_course_authoring.CourseAccessRole", CourseAccessRole)
     @patch("openedx_authz.management.commands.authz_migrate_course_authoring.migrate_legacy_course_roles_to_authz")

--- a/openedx_authz/tests/test_migrations.py
+++ b/openedx_authz/tests/test_migrations.py
@@ -196,6 +196,7 @@ class TestLegacyCourseAuthoringPermissionsMigration(TestCase):
             "org": self.org,
             "course_id": self.course_id,
         }
+        self.invalid_course = f"ccx-v1:{self.org}+{OBJECT_PREFIX}+2026_01+ccx@2"
         self.course_overview = CourseOverview.objects.create(
             id=self.course_id, org=self.org, display_name=f"{OBJECT_PREFIX} Course"
         )
@@ -884,11 +885,32 @@ class TestLegacyCourseAuthoringPermissionsMigration(TestCase):
             )
 
     @patch("openedx_authz.api.data.CourseOverview", CourseOverview)
+    def test_migrate_authz_to_legacy_course_roles_with_invalid_courses(self):
+        with self.assertRaises(ValueError):
+            migrate_authz_to_legacy_course_roles(
+                CourseAccessRole,
+                UserSubject,
+                course_id_list=[self.invalid_course],
+                org_id=None,
+                delete_after_migration=True,
+            )
+
+    @patch("openedx_authz.api.data.CourseOverview", CourseOverview)
     def test_migrate_legacy_course_roles_to_authz_with_no_org_and_courses(self):
         # Migrate from legacy CourseAccessRole to new Casbin-based model
         with self.assertRaises(ValueError):
             migrate_legacy_course_roles_to_authz(
                 CourseAccessRole, course_id_list=None, org_id=None, delete_after_migration=True
+            )
+
+    @patch("openedx_authz.api.data.CourseOverview", CourseOverview)
+    def test_migrate_legacy_course_roles_to_authz_with_invalid_courses(self):
+        with self.assertRaises(ValueError):
+            migrate_legacy_course_roles_to_authz(
+                CourseAccessRole,
+                course_id_list=[self.invalid_course],
+                org_id=None,
+                delete_after_migration=True,
             )
 
     @patch("openedx_authz.management.commands.authz_migrate_course_authoring.CourseAccessRole", CourseAccessRole)

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -8,6 +8,7 @@ attrs                       # Classes without boilerplate
 pycasbin                    # Authorization library for implementing access control models
 casbin-django-orm-adapter   # Adapter for Django ORM for Casbin
 edx-opaque-keys             # Opaque keys for resource identification
+edx-ccx-keys                # CCX keys for Custom Course identification
 edx-api-doc-tools           # Tools for API documentation
 edx-django-utils            # Used for RequestCache
 edx-drf-extensions          # Extensions for Django Rest Framework used by Open edX

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -64,6 +64,8 @@ drf-yasg==1.21.11
     # via edx-api-doc-tools
 edx-api-doc-tools==2.1.2
     # via -r requirements/base.in
+edx-ccx-keys==2.0.2
+    # via -r requirements/base.in
 edx-django-utils==8.0.1
     # via
     #   -r requirements/base.in
@@ -75,6 +77,7 @@ edx-drf-extensions==10.6.0
 edx-opaque-keys==3.0.0
     # via
     #   -r requirements/base.in
+    #   edx-ccx-keys
     #   edx-drf-extensions
     #   edx-organizations
 edx-organizations==7.3.0
@@ -115,6 +118,8 @@ semantic-version==2.10.0
     # via edx-drf-extensions
 simpleeval==1.0.3
     # via pycasbin
+six==1.17.0
+    # via edx-ccx-keys
 sqlparse==0.5.3
     # via django
 stevedore==5.5.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -15,7 +15,7 @@ astroid==4.0.3
     #   pylint-celery
 attrs==25.3.0
     # via -r requirements/quality.txt
-build==1.4.0
+build==1.4.2
     # via
     #   -r requirements/pip-tools.txt
     #   pip-tools
@@ -140,6 +140,8 @@ drf-yasg==1.21.11
     #   edx-api-doc-tools
 edx-api-doc-tools==2.1.2
     # via -r requirements/quality.txt
+edx-ccx-keys==2.0.2
+    # via -r requirements/quality.txt
 edx-django-utils==8.0.1
     # via
     #   -r requirements/quality.txt
@@ -155,6 +157,7 @@ edx-lint==5.6.0
 edx-opaque-keys==3.0.0
     # via
     #   -r requirements/quality.txt
+    #   edx-ccx-keys
     #   edx-drf-extensions
     #   edx-organizations
 edx-organizations==7.3.0
@@ -338,6 +341,7 @@ simpleeval==1.0.3
 six==1.17.0
     # via
     #   -r requirements/quality.txt
+    #   edx-ccx-keys
     #   edx-lint
 snowballstemmer==3.0.1
     # via

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -119,6 +119,8 @@ drf-yasg==1.21.11
     #   edx-api-doc-tools
 edx-api-doc-tools==2.1.2
     # via -r requirements/test.txt
+edx-ccx-keys==2.0.2
+    # via -r requirements/test.txt
 edx-django-utils==8.0.1
     # via
     #   -r requirements/test.txt
@@ -130,6 +132,7 @@ edx-drf-extensions==10.6.0
 edx-opaque-keys==3.0.0
     # via
     #   -r requirements/test.txt
+    #   edx-ccx-keys
     #   edx-drf-extensions
     #   edx-organizations
 edx-organizations==7.3.0
@@ -292,6 +295,10 @@ simpleeval==1.0.3
     # via
     #   -r requirements/test.txt
     #   pycasbin
+six==1.17.0
+    # via
+    #   -r requirements/test.txt
+    #   edx-ccx-keys
 snowballstemmer==3.0.1
     # via sphinx
 soupsieve==2.8

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file=requirements/pip-tools.txt requirements/pip-tools.in
 #
-build==1.4.0
+build==1.4.2
     # via pip-tools
 click==8.3.1
     # via pip-tools

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -109,6 +109,8 @@ drf-yasg==1.21.11
     #   edx-api-doc-tools
 edx-api-doc-tools==2.1.2
     # via -r requirements/test.txt
+edx-ccx-keys==2.0.2
+    # via -r requirements/test.txt
 edx-django-utils==8.0.1
     # via
     #   -r requirements/test.txt
@@ -122,6 +124,7 @@ edx-lint==5.6.0
 edx-opaque-keys==3.0.0
     # via
     #   -r requirements/test.txt
+    #   edx-ccx-keys
     #   edx-drf-extensions
     #   edx-organizations
 edx-organizations==7.3.0
@@ -250,7 +253,10 @@ simpleeval==1.0.3
     #   -r requirements/test.txt
     #   pycasbin
 six==1.17.0
-    # via edx-lint
+    # via
+    #   -r requirements/test.txt
+    #   edx-ccx-keys
+    #   edx-lint
 snowballstemmer==3.0.1
     # via pydocstyle
 sqlparse==0.5.3

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -94,6 +94,8 @@ drf-yasg==1.21.11
     #   edx-api-doc-tools
 edx-api-doc-tools==2.1.2
     # via -r requirements/base.txt
+edx-ccx-keys==2.0.2
+    # via -r requirements/base.txt
 edx-django-utils==8.0.1
     # via
     #   -r requirements/base.txt
@@ -105,6 +107,7 @@ edx-drf-extensions==10.6.0
 edx-opaque-keys==3.0.0
     # via
     #   -r requirements/base.txt
+    #   edx-ccx-keys
     #   edx-drf-extensions
     #   edx-organizations
 edx-organizations==7.3.0
@@ -196,6 +199,10 @@ simpleeval==1.0.3
     # via
     #   -r requirements/base.txt
     #   pycasbin
+six==1.17.0
+    # via
+    #   -r requirements/base.txt
+    #   edx-ccx-keys
 sqlparse==0.5.3
     # via
     #   -r requirements/base.txt

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py312-django{42,52}
+envlist = py312-django{52}
 
 [doc8]
 ; D001 = Line too long
@@ -37,7 +37,6 @@ norecursedirs = .* docs requirements site-packages
 
 [testenv]
 deps =
-    django42: Django>=4.0,<5.0
     django52: Django>=5.0,<5.3
     -r{toxinidir}/requirements/test.txt
 commands =


### PR DESCRIPTION
This PR attempts to address the issues detailed in https://github.com/openedx/openedx-authz/issues/235 .  There are 4 overlapping sets of problems:

1. The CCX Coach role was occasionally being queried in RBAC, but didn't exist
2. CCX course identifiers were being passed into RBAC permission checks (as they are technically courses), but RBAC didn't have a scope for those keys. This will happen with any non-course-v1 course locator, see below.
3. It was possible to migrate / rollback permissions for CCX courses which would fail to do anything but report success. Migrating or rolling back the permissions on the parent course with `--delete` could cause the CCX course to be left in a state where there was no CCX Coach to run the course and rollback would not re-grant the role
4. It was possible to turn on the RBAC course override flag for a CCX course, which actually does nothing since all of the CCX checks are in the LMS

This PR addresses 1 and 2 by adding a `CCXCourseOverviewData` class and `CCX_COACH` that grant no permissions, but satisfy the checks for existence. This also allows the `ccx_coach` role to be migrated / rolled back without error.

It addresses 3 by not allowing CCX courses to be migrated / rolled back using the migration scripts, and by better surfacing those errors.

**It does not address 4** as that should happen as part of https://github.com/openedx/openedx-platform/issues/38145 , but in that task it should throw an error if trying to turn on the RBAC flag for any  non-course-v1 course until we are ready to support them.

**It does not address other non-course-v1 locators**. To the best of our (myself, Dave Ormsbee, Kyle McCormick) only know of one other possible case like this- Old Mongo keys. These are largely unsupported (do not work at all in Studio or Courseware, may not even show up on the student dashboard) and, as near as anyone can tell, un-testable.

If this approach looks good I will complete the rest of the merge checklist and update 38145 with details. This branch is tested in openedx-platform [here](https://github.com/openedx/openedx-platform/pull/38286).

## Notes on CCX roles and permissions

1. The CCX Coach role is granted on the **parent**  (course-v1) course, it is "the permission to create a single CCX course and manage it using the CCX Coach dashboard and a subset of the Instructor dashboard"
2. When the CCX Coach creates a CCX course from the parent course (in the LMS Instructor Dashboard of the parent course), they are automatically granted the legacy `staff` role on the CCX course as well.
3. At least 1 (maybe all?) instructors on the parent course are also granted the legacy `instructor` and `staff` on the CCX course

## Testing

I do not expect anyone to do this, but here is what I did.

### Setup
0. Make sure CCX is enabled on your instance (Add `CUSTOM_COURSES_EDX: true` to the Tutor patch "common-env-features")
1. Create course admin user (not staff or superuser)
    a. Create through the normal UI
    b. Log into studio as the user (will probably error, but creates a needed row in the database)
    c. As superuser go to http://studio.local.openedx.io/admin/course_creators/coursecreator/
        i. Your new user should show up in the list, mark them as "granted"
        ii. Using "All Organizations" didn't work for me, courses wouldn't create, I had to add specific orgs to the user. You may have to create one first by creating a course as a superuser.
    d. As superuser go to http://studio.local.openedx.io/admin/auth/user/
        i. Click on your new user and mark them as "active" in the Permissions section, then save. !! There is an "is_active" flag under account recovery, that is the wrong one.
5. Create ccx coach user (not staff or superuser)
    a. Create through the normal UI
    b. Mark "active" in the Django admin as above

### Test

All tests should complete without error.

1. Create course as the course creator user
    a. Add some content / change course start date to a date in the past / publish
    b. View in LMS
    c. Get into correct configuration
        *If CCX:*
            i. As course creator: Studio -> Advanced Settings -> set CCX enabled `true`
            ii. As course creator: Add the coach user to the course - LMS -> Instructor dashboard -> Membership -> Course Team Management -> CCX Coaches role, enter the coach username, add
            iii. As coach: LMS -> CCX Coach -> CCX Coach Dashboard -> Enter name, create 
            iv. Due to an unrelated bug you must force publish the CCX course here before it will work: http://studio.local.openedx.io/admin/contentstore/courseoutlineregenerate/ (check the course box, from the "actions" box select "Regenerate selected course outlines", click "go")
            v. Click through all of the CCX Coach Dashboard options, try everything
        *If RBAC:*
            i. Turn on the course override waffle flag for the parent and/or CCX course: http://studio.local.openedx.io/admin/waffle_utils/waffleflagcourseoverridemodel/
4. Update parent course
    a. Add / change content
    b. Publish
    c. View in LMS, content should be up to date 
6. If CCX and RBAC try with the waffle flags on and off for both the parent and CCX course


**Merge checklist:**
Check off if complete *or* not applicable:
- [x] Version bumped
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [ ] Fixup commits are squashed away
- [x] Unit tests added/updated
- [x] Manual testing instructions provided
- [x] Noted any: Concerns, dependencies, migration issues, deadlines, tickets
