### PR TITLE
docs: add course roles doc

### DIFF
--- a/docs/concepts/core_roles_and_permissions/course_roles.rst
+++ b/docs/concepts/core_roles_and_permissions/course_roles.rst
@@ -22,7 +22,7 @@ A **role** is a set of permissions that defines what actions a user can perform.
 
 - The **Course Editor** can create and edit content within a course but cannot publish it. They support the authoring process while leaving final publishing to Staff or Admins.
 
-- The **Course Auditor** can view and reuse content but cannot edit or delete anything.
+- The **Course Auditor** provides view-only access for general oversight, compliance review, and QA. This role cannot edit, delete, or modify any content in Studio.
 
 .. note::
 
@@ -42,7 +42,7 @@ Course Access & Content
 
 Library Updates
 ========================
-- **Review library updates** (``courses.manage_library_updates``): Allows users to accept or reject library updates in Studio.
+- **Manage library updates** (``courses.manage_library_updates``): Allows users to accept or reject library updates in Studio.
 
 Course Updates & Handouts
 ===========================
@@ -63,9 +63,8 @@ Files
 
 Schedule & Details
 ===================
-- **View schedule** (``courses.view_schedule``): Allows users to view the course schedule.
+- **View schedule and details** (``courses.view_schedule_and_details``): Allows users to view the course schedule and details.
 - **Edit schedule** (``courses.edit_schedule``): Allows users to edit the course schedule.
-- **View course details** (``courses.view_details``): Allows users to view course details.
 - **Edit course details** (``courses.edit_details``): Allows users to edit course details, including summary, pacing, and prerequisites.
 
 Grading
@@ -139,9 +138,8 @@ Roles and Permissions Summary Table
    courses.delete_files                          ✅             ✅             ❌                    ❌
    **Schedule & Details**
    --------------------------------------------- -------------- -------------- --------------------- --------------
-   courses.view_schedule                         ✅             ✅             ✅                    ✅
+   courses.view_schedule_and_details             ✅             ✅             ✅                    ✅
    courses.edit_schedule                         ✅             ✅             ❌                    ❌
-   courses.view_details                          ✅             ✅             ✅                    ✅
    courses.edit_details                          ✅             ✅             ✅                    ❌
    **Library Updates**
    --------------------------------------------- -------------- -------------- --------------------- --------------

--- a/docs/concepts/core_roles_and_permissions/course_roles.rst
+++ b/docs/concepts/core_roles_and_permissions/course_roles.rst
@@ -1,0 +1,149 @@
+.. _Roles Permissions Course:
+
+Core Roles and Permissions: Course
+##################################
+
+This document outlines the built-in roles and permissions associated with the Course feature in the Open edX platform.
+
+.. contents::
+    :depth: 2
+    :local:
+
+.. _Course Roles:
+
+Roles
+-----
+
+A **role** is a set of permissions that defines what actions a user can perform. When you **grant a role to a user**, you assign it within a specific scope, which determines where those permissions apply. Here is the list of default roles for Courses.
+
+- The **Course Admin** has full control over the course, including managing users, modifying content, and handling publishing workflows. They ensure content is properly maintained and accessible as needed.
+
+- The **Course Staff** is responsible for creating, editing, and publishing content within a course. They can manage tags and advanced settings but cannot delete courses or manage users.
+
+- The **Course Contributor** can create and edit content within a course but cannot publish it. They support the authoring process while leaving final publishing to Staff or Admins.
+
+- The **Course Auditor** can view and reuse content but cannot edit or delete anything.
+
+.. note::
+
+   Global staff and superusers are like Course Admins on all courses (they have full permissions across all courses by default).
+
+Permissions
+-----------
+
+The following permissions are associated with the course roles:
+
+Course Permissions
+==================
+
+- **View course** (``courses.view_course``): Allows users to view the course and access the course outline in read-only mode.
+- **Create course** (``courses.create_course``): Allows users to create a new course in Studio.
+- **Edit course content** (``courses.edit_course_content``): Allows users to edit course content, outline, units, and components.
+- **Publish course content** (``courses.publish_course_content``): Allows users to publish course content.
+- **Review library updates** (``courses.manage_library_updates``): Allows users to accept or reject library updates in Studio.
+- **View course updates** (``courses.view_course_updates``): Allows users to view course updates and handouts.
+- **Manage course updates** (``courses.manage_course_updates``): Allows users to manage course updates and handouts, including creating, editing, and deleting.
+- **View pages & resources** (``courses.view_pages_and_resources``): Allows users to view pages and resources.
+- **Manage pages & resources** (``courses.manage_pages_and_resources``): Allows users to edit pages and resources, including toggles and content managed from that section.
+- **View files** (``courses.view_files``): Allows users to view the Files page.
+- **Create files** (``courses.create_files``): Allows users to upload files.
+- **Edit files** (``courses.edit_files``): Allows users to perform non-destructive file actions, such as lock or unlock.
+- **Delete files** (``courses.delete_files``): Allows users to delete files.
+- **View schedule** (``courses.view_schedule``): Allows users to view the course schedule.
+- **Edit schedule** (``courses.edit_schedule``): Allows users to edit the course schedule.
+- **View course details** (``courses.view_details``): Allows users to view course details.
+- **Edit course details** (``courses.edit_details``): Allows users to edit course details, including summary, pacing, and prerequisites.
+- **View grading settings** (``courses.view_grading_settings``): Allows users to view grading settings.
+- **Edit grading settings** (``courses.edit_grading_settings``): Allows users to edit grading settings.
+- **View course team** (``courses.view_course_team``): Allows users to view the course team roster.
+- **Manage course team** (``courses.manage_course_team``): Allows users to edit course team membership and roles.
+- **Manage group configuration** (``courses.manage_group_configurations``): Allows users to manage content groups.
+- **Manage tags** (``courses.manage_tags``): Allows users to create, edit, and delete tags.
+- **Manage taxonomies** (``courses.manage_taxonomies``): Allows users to create, edit, and delete taxonomies.
+- **Manage advanced settings** (``courses.manage_advanced_settings``): Allows users to access and edit advanced settings.
+- **Manage certificates** (``courses.manage_certificates``): Allows users to access and edit certificates.
+- **Import course** (``courses.import_course``): Allows users to import course content.
+- **Export course** (``courses.export_course``): Allows users to export course content.
+- **Export tags** (``courses.export_tags``): Allows users to export tags.
+- **View checklists** (``courses.view_checklists``): Allows users to view checklists.
+- **View global staff & super admins** (``courses.view_global_staff_and_superadmins``): Allows course admins to view the list of global staff and super admin users.
+
+.. _Course RP Summary Table:
+
+Roles and Permissions Summary Table
+-----------------------------------
+
+.. START COURSE RP TABLE:
+
+.. table:: Matrix of Course Roles and Permissions
+   :widths: auto
+
+   ============================================= ============== ============== ===================== ==============
+   Permissions                                   Course Admin   Course Staff   Course Contributor    Course Auditor
+   ============================================= ============== ============== ===================== ==============
+   **Access & Content**
+   --------------------------------------------- -------------- -------------- --------------------- --------------
+   courses.view_course                           ✅             ✅             ✅                    ✅
+   courses.create_course                         ✅             ✅             ✅                    ❌
+   courses.edit_course_content                   ✅             ✅             ✅                    ❌
+   courses.publish_course_content                ✅             ✅             ❌                    ❌
+   **Library Updates**
+   --------------------------------------------- -------------- -------------- --------------------- --------------
+   courses.manage_library_updates                ✅             ✅             ❌                    ❌
+   **Updates & Handouts**
+   --------------------------------------------- -------------- -------------- --------------------- --------------
+   courses.view_course_updates                   ✅             ✅             ✅                    ✅
+   courses.manage_course_updates                 ✅             ✅             ❌                    ❌
+   **Pages & Resources**
+   --------------------------------------------- -------------- -------------- --------------------- --------------
+   courses.view_pages_and_resources              ✅             ✅             ✅                    ✅
+   courses.manage_pages_and_resources            ✅             ✅             ❌                    ❌
+   **Files**
+   --------------------------------------------- -------------- -------------- --------------------- --------------
+   courses.view_files                            ✅             ✅             ✅                    ✅
+   courses.create_files                          ✅             ✅             ✅                    ❌
+   courses.edit_files                            ✅             ✅             ✅                    ❌
+   courses.delete_files                          ✅             ✅             ❌                    ❌
+   **Schedule & Details**
+   --------------------------------------------- -------------- -------------- --------------------- --------------
+   courses.view_schedule                         ✅             ✅             ✅                    ✅
+   courses.edit_schedule                         ✅             ✅             ❌                    ❌
+   courses.view_details                          ✅             ✅             ✅                    ✅
+   courses.edit_details                          ✅             ✅             ❌                    ❌
+   **Grading**
+   --------------------------------------------- -------------- -------------- --------------------- --------------
+   courses.view_grading_settings                 ✅             ✅             ✅                    ✅
+   courses.edit_grading_settings                 ✅             ✅             ❌                    ❌
+   **Team & Groups**
+   --------------------------------------------- -------------- -------------- --------------------- --------------
+   courses.view_course_team                      ✅             ✅             ✅                    ✅
+   courses.manage_course_team                    ✅             ❌             ❌                    ❌
+   courses.manage_group_configurations           ✅             ✅             ❌                    ❌
+   **Tags & Taxonomies**
+   --------------------------------------------- -------------- -------------- --------------------- --------------
+   courses.manage_tags                           ✅             ✅             ❌                    ❌
+   courses.manage_taxonomies                     ✅             ✅             ❌                    ❌
+   **Advanced & Certificates**
+   --------------------------------------------- -------------- -------------- --------------------- --------------
+   courses.manage_advanced_settings              ✅             ✅             ❌                    ❌
+   courses.manage_certificates                   ✅             ✅             ❌                    ❌
+   **Import / Export**
+   --------------------------------------------- -------------- -------------- --------------------- --------------
+   courses.import_course                         ✅             ❌             ❌                    ❌
+   courses.export_course                         ✅             ✅             ❌                    ❌
+   courses.export_tags                           ✅             ✅             ❌                    ❌
+   **Other**
+   --------------------------------------------- -------------- -------------- --------------------- --------------
+   courses.view_checklists                       ✅             ✅             ✅                    ✅
+   courses.view_global_staff_and_superadmins     ✅             ❌             ❌                    ❌
+   ============================================= ============== ============== ===================== ==============
+
+.. END COURSE RP TABLE
+
+**Maintenance chart**
+
++--------------+-------------------------------+----------------+--------------------------------+
+| Review Date  | Working Group Reviewer        | Release        | Test situation                 |
++--------------+-------------------------------+----------------+--------------------------------+
+| 2026-05-19   | RBAC Project                  | Verawood       | TO DO                          |
++--------------+-------------------------------+----------------+--------------------------------+

--- a/docs/concepts/core_roles_and_permissions/course_roles.rst
+++ b/docs/concepts/core_roles_and_permissions/course_roles.rst
@@ -97,7 +97,6 @@ Import / Export
 Other
 =====
 - **View checklists** (``courses.view_checklists``): Allows users to view checklists.
-- **View global staff & super admins** (``courses.view_global_staff_and_superadmins``): Allows course admins to view the list of global staff and super admin users.
 
 .. _Course RP Summary Table:
 
@@ -165,7 +164,6 @@ Roles and Permissions Summary Table
    **Other**
    --------------------------------------------- -------------- -------------- --------------------- --------------
    courses.view_checklists                       ✅             ✅             ✅                    ✅
-   courses.view_global_staff_and_superadmins     ✅             ✅             ✅                    ❌
    ============================================= ============== ============== ===================== ==============
 
 .. END COURSE RP TABLE

--- a/docs/concepts/core_roles_and_permissions/course_roles.rst
+++ b/docs/concepts/core_roles_and_permissions/course_roles.rst
@@ -20,7 +20,7 @@ A **role** is a set of permissions that defines what actions a user can perform.
 
 - The **Course Staff** is responsible for creating, editing, and publishing content within a course. They can manage tags and advanced settings but cannot delete courses or manage users.
 
-- The **Course Contributor** can create and edit content within a course but cannot publish it. They support the authoring process while leaving final publishing to Staff or Admins.
+- The **Course Editor** can create and edit content within a course but cannot publish it. They support the authoring process while leaving final publishing to Staff or Admins.
 
 - The **Course Auditor** can view and reuse content but cannot edit or delete anything.
 
@@ -33,38 +33,70 @@ Permissions
 
 The following permissions are associated with the course roles:
 
-Course Permissions
-==================
-
+Course Access & Content
+=========================
 - **View course** (``courses.view_course``): Allows users to view the course and access the course outline in read-only mode.
 - **Create course** (``courses.create_course``): Allows users to create a new course in Studio.
 - **Edit course content** (``courses.edit_course_content``): Allows users to edit course content, outline, units, and components.
 - **Publish course content** (``courses.publish_course_content``): Allows users to publish course content.
+
+Library Updates
+========================
 - **Review library updates** (``courses.manage_library_updates``): Allows users to accept or reject library updates in Studio.
+
+Course Updates & Handouts
+===========================
 - **View course updates** (``courses.view_course_updates``): Allows users to view course updates and handouts.
 - **Manage course updates** (``courses.manage_course_updates``): Allows users to manage course updates and handouts, including creating, editing, and deleting.
+
+Pages & Resources
+====================
 - **View pages & resources** (``courses.view_pages_and_resources``): Allows users to view pages and resources.
 - **Manage pages & resources** (``courses.manage_pages_and_resources``): Allows users to edit pages and resources, including toggles and content managed from that section.
+
+Files
+=======
 - **View files** (``courses.view_files``): Allows users to view the Files page.
 - **Create files** (``courses.create_files``): Allows users to upload files.
 - **Edit files** (``courses.edit_files``): Allows users to perform non-destructive file actions, such as lock or unlock.
 - **Delete files** (``courses.delete_files``): Allows users to delete files.
+
+Schedule & Details
+===================
 - **View schedule** (``courses.view_schedule``): Allows users to view the course schedule.
 - **Edit schedule** (``courses.edit_schedule``): Allows users to edit the course schedule.
 - **View course details** (``courses.view_details``): Allows users to view course details.
 - **Edit course details** (``courses.edit_details``): Allows users to edit course details, including summary, pacing, and prerequisites.
+
+Grading
+=========
 - **View grading settings** (``courses.view_grading_settings``): Allows users to view grading settings.
 - **Edit grading settings** (``courses.edit_grading_settings``): Allows users to edit grading settings.
+
+Course Team & Groups
+====================
 - **View course team** (``courses.view_course_team``): Allows users to view the course team roster.
 - **Manage course team** (``courses.manage_course_team``): Allows users to edit course team membership and roles.
 - **Manage group configuration** (``courses.manage_group_configurations``): Allows users to manage content groups.
+
+Tags & Taxonomies
+=================
 - **Manage tags** (``courses.manage_tags``): Allows users to create, edit, and delete tags.
 - **Manage taxonomies** (``courses.manage_taxonomies``): Allows users to create, edit, and delete taxonomies.
+
+Advanced & Certificates
+=======================
 - **Manage advanced settings** (``courses.manage_advanced_settings``): Allows users to access and edit advanced settings.
 - **Manage certificates** (``courses.manage_certificates``): Allows users to access and edit certificates.
+
+Import / Export
+================
 - **Import course** (``courses.import_course``): Allows users to import course content.
 - **Export course** (``courses.export_course``): Allows users to export course content.
 - **Export tags** (``courses.export_tags``): Allows users to export tags.
+
+Other
+=====
 - **View checklists** (``courses.view_checklists``): Allows users to view checklists.
 - **View global staff & super admins** (``courses.view_global_staff_and_superadmins``): Allows course admins to view the list of global staff and super admin users.
 
@@ -79,25 +111,26 @@ Roles and Permissions Summary Table
    :widths: auto
 
    ============================================= ============== ============== ===================== ==============
-   Permissions                                   Course Admin   Course Staff   Course Contributor    Course Auditor
+   Permissions                                   Course Admin   Course Staff   Course Editor         Course Auditor
    ============================================= ============== ============== ===================== ==============
-   **Access & Content**
+   **Tags & Taxonomies**
    --------------------------------------------- -------------- -------------- --------------------- --------------
-   courses.view_course                           ✅             ✅             ✅                    ✅
-   courses.create_course                         ✅             ✅             ✅                    ❌
-   courses.edit_course_content                   ✅             ✅             ✅                    ❌
-   courses.publish_course_content                ✅             ✅             ❌                    ❌
-   **Library Updates**
-   --------------------------------------------- -------------- -------------- --------------------- --------------
-   courses.manage_library_updates                ✅             ✅             ❌                    ❌
+   courses.manage_tags                           ✅             ✅             ✅                    ❌
+   courses.manage_taxonomies                     ✅             ❌             ❌                    ❌
    **Updates & Handouts**
    --------------------------------------------- -------------- -------------- --------------------- --------------
    courses.view_course_updates                   ✅             ✅             ✅                    ✅
-   courses.manage_course_updates                 ✅             ✅             ❌                    ❌
-   **Pages & Resources**
+   courses.manage_course_updates                 ✅             ✅             ✅                    ❌
+   **Advanced & Certificates**
    --------------------------------------------- -------------- -------------- --------------------- --------------
-   courses.view_pages_and_resources              ✅             ✅             ✅                    ✅
-   courses.manage_pages_and_resources            ✅             ✅             ❌                    ❌
+   courses.manage_advanced_settings              ✅             ✅             ❌                    ❌
+   courses.manage_certificates                   ✅             ✅             ❌                    ❌
+   **Access & Content**
+   --------------------------------------------- -------------- -------------- --------------------- --------------
+   courses.view_course                           ✅             ✅             ✅                    ✅
+   courses.create_course                         ❌             ❌             ❌                    ❌
+   courses.publish_course_content                ✅             ✅             ❌                    ❌
+   courses.edit_course_content                   ✅             ✅             ✅                    ❌
    **Files**
    --------------------------------------------- -------------- -------------- --------------------- --------------
    courses.view_files                            ✅             ✅             ✅                    ✅
@@ -109,33 +142,32 @@ Roles and Permissions Summary Table
    courses.view_schedule                         ✅             ✅             ✅                    ✅
    courses.edit_schedule                         ✅             ✅             ❌                    ❌
    courses.view_details                          ✅             ✅             ✅                    ✅
-   courses.edit_details                          ✅             ✅             ❌                    ❌
+   courses.edit_details                          ✅             ✅             ✅                    ❌
+   **Library Updates**
+   --------------------------------------------- -------------- -------------- --------------------- --------------
+   courses.manage_library_updates                ✅             ✅             ✅                    ❌
    **Grading**
    --------------------------------------------- -------------- -------------- --------------------- --------------
    courses.view_grading_settings                 ✅             ✅             ✅                    ✅
-   courses.edit_grading_settings                 ✅             ✅             ❌                    ❌
+   courses.edit_grading_settings                 ✅             ✅             ✅                    ❌
+   **Pages & Resources**
+   --------------------------------------------- -------------- -------------- --------------------- --------------
+   courses.view_pages_and_resources              ✅             ✅             ✅                    ✅
+   courses.manage_pages_and_resources            ✅             ✅             ✅                    ❌
+   **Import / Export**
+   --------------------------------------------- -------------- -------------- --------------------- --------------
+   courses.import_course                         ✅             ✅             ❌                    ❌
+   courses.export_course                         ✅             ✅             ❌                    ❌
+   courses.export_tags                           ✅             ✅             ❌                    ❌
    **Team & Groups**
    --------------------------------------------- -------------- -------------- --------------------- --------------
    courses.view_course_team                      ✅             ✅             ✅                    ✅
+   courses.manage_group_configurations           ✅             ✅             ✅                    ❌
    courses.manage_course_team                    ✅             ❌             ❌                    ❌
-   courses.manage_group_configurations           ✅             ✅             ❌                    ❌
-   **Tags & Taxonomies**
-   --------------------------------------------- -------------- -------------- --------------------- --------------
-   courses.manage_tags                           ✅             ✅             ❌                    ❌
-   courses.manage_taxonomies                     ✅             ✅             ❌                    ❌
-   **Advanced & Certificates**
-   --------------------------------------------- -------------- -------------- --------------------- --------------
-   courses.manage_advanced_settings              ✅             ✅             ❌                    ❌
-   courses.manage_certificates                   ✅             ✅             ❌                    ❌
-   **Import / Export**
-   --------------------------------------------- -------------- -------------- --------------------- --------------
-   courses.import_course                         ✅             ❌             ❌                    ❌
-   courses.export_course                         ✅             ✅             ❌                    ❌
-   courses.export_tags                           ✅             ✅             ❌                    ❌
    **Other**
    --------------------------------------------- -------------- -------------- --------------------- --------------
    courses.view_checklists                       ✅             ✅             ✅                    ✅
-   courses.view_global_staff_and_superadmins     ✅             ❌             ❌                    ❌
+   courses.view_global_staff_and_superadmins     ✅             ✅             ✅                    ❌
    ============================================= ============== ============== ===================== ==============
 
 .. END COURSE RP TABLE

--- a/docs/concepts/core_roles_and_permissions/index.rst
+++ b/docs/concepts/core_roles_and_permissions/index.rst
@@ -5,3 +5,4 @@ Core Roles and Permissions
     :maxdepth: 1
 
     content_library_roles
+    course_roles


### PR DESCRIPTION
## Description

Adds a doc on roles and permissions for courses.

Resolves #279

## How to test

Review the doc: https://docsopenedxorg--293.org.readthedocs.build/projects/openedx-authz/en/293/concepts/core_roles_and_permissions/course_roles.html and compare it with the roles and permissions in the console or in the [wiki page](https://openedx.atlassian.net/wiki/spaces/OEPM/pages/5638619138/Authoring+Roles+and+Permissions).
