### PR TITLE
fix: Remove libraries v2 check from enforcer.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,17 @@ Unreleased
 
 *
 
+0.20.1 - 2026-05-21
+********************
+
+Changed
+=======
+
+* Removed checks for libraries v2 when the enforcer is loaded. This was
+  originally add to improve performance, but a circular import on
+  openedx-platform caused it to always default to true. This ensures that the
+  enforcer continues to work even if the circular import is resolved.
+
 0.20.0 - 2025-11-27
 ********************
 

--- a/openedx_authz/__init__.py
+++ b/openedx_authz/__init__.py
@@ -4,6 +4,6 @@ Open edX AuthZ provides the architecture and foundations of the authorization fr
 
 import os
 
-__version__ = "0.20.0"
+__version__ = "0.20.1"
 
 ROOT_DIRECTORY = os.path.dirname(os.path.abspath(__file__))

--- a/openedx_authz/engine/enforcer.py
+++ b/openedx_authz/engine/enforcer.py
@@ -27,19 +27,6 @@ from django.conf import settings
 from openedx_authz.engine.adapter import ExtendedAdapter
 from openedx_authz.models.engine import PolicyCacheControl
 
-
-def libraries_v2_enabled() -> bool:
-    """Dummy toggle that is always enabled."""
-    return True
-
-
-if getattr(settings, "SERVICE_VARIANT", None) == "cms":
-    try:
-        from cms.djangoapps.contentstore.toggles import libraries_v2_enabled
-    except ImportError:
-        # If the CMS is not available, use the dummy toggle.
-        pass
-
 logger = logging.getLogger(__name__)
 
 
@@ -221,15 +208,7 @@ class AuthzEnforcer:
         # (re)load policy if needed
         cls.load_policy_if_needed()
 
-        # HACK: This code block will only be useful when in Ulmo to deactivate
-        # the enforcer when the new library experience is disabled. It should be
-        # removed for the next release cycle.
-        # When replaced, we will only need to configure the enforcer here. Which
-        # is in charge of enabling/disabling auto-load and auto-save.
-        if libraries_v2_enabled():
-            cls.configure_enforcer_auto_save_and_load()
-        else:
-            cls.deactivate_enforcer()
+        cls.configure_enforcer_auto_save_and_load()
 
         return cls._enforcer
 

--- a/openedx_authz/tests/test_enforcer.py
+++ b/openedx_authz/tests/test_enforcer.py
@@ -6,7 +6,6 @@ that would be used in production environments.
 """
 
 import time
-from unittest.mock import patch
 from uuid import uuid4
 
 import casbin
@@ -556,277 +555,6 @@ class TestAutoLoadPolicy(TransactionTestCase):
             self.assertGreater(len(policies_after_manual_load), 0)
 
 
-class TestEnforcerToggleBehavior(TransactionTestCase):
-    """Test cases for enforcer behavior with libraries_v2_enabled toggle.
-
-    These tests verify that the enforcer correctly responds to the
-    libraries_v2_enabled toggle state, enabling/disabling auto-save
-    and auto-load as appropriate.
-
-    Uses TransactionTestCase to ensure clean state between tests.
-    """
-
-    def setUp(self):
-        """Set up test environment with clean enforcer state."""
-        super().setUp()
-        # Reset the singleton enforcer before each test
-        AuthzEnforcer._enforcer = None  # pylint: disable=protected-access
-
-    def tearDown(self):
-        """Clean up enforcer state after test."""
-        if AuthzEnforcer._enforcer:  # pylint: disable=protected-access
-            try:
-                AuthzEnforcer.deactivate_enforcer()
-            except Exception:  # pylint: disable=broad-exception-caught
-                pass
-        AuthzEnforcer._enforcer = None  # pylint: disable=protected-access
-        super().tearDown()
-
-    @patch("openedx_authz.engine.enforcer.libraries_v2_enabled")
-    @override_settings(CASBIN_AUTO_LOAD_POLICY_INTERVAL=0)
-    def test_enforcer_auto_save_enabled_when_toggle_enabled(self, mock_toggle):
-        """Test that auto-save is enabled when libraries_v2_enabled toggle is on.
-
-        Expected result:
-            - Enforcer is initialized with auto-save enabled
-            - Policy changes are persisted to database
-            - CASBIN_AUTO_LOAD_POLICY_INTERVAL=0 doesn't disable auto-save
-        """
-        mock_toggle.return_value = True
-
-        enforcer = AuthzEnforcer.get_enforcer()
-
-        self.assertTrue(AuthzEnforcer.is_auto_save_enabled())
-
-        test_policy = [
-            make_role_key("test_role"),
-            make_action_key("test_action"),
-            make_scope_key("lib", "*"),
-            "allow",
-        ]
-        enforcer.add_policy(*test_policy)
-
-        enforcer.load_policy()
-        policies = enforcer.get_policy()
-
-        self.assertIn(test_policy, policies)
-
-    @patch("openedx_authz.engine.enforcer.libraries_v2_enabled")
-    @override_settings(CASBIN_AUTO_LOAD_POLICY_INTERVAL=0)
-    def test_enforcer_deactivated_when_toggle_disabled(self, mock_toggle):
-        """Test that enforcer is deactivated when libraries_v2_enabled toggle is off.
-
-        Expected result:
-            - Enforcer is initialized but deactivated
-            - Auto-save is disabled via deactivate_enforcer
-            - Auto-load is stopped
-        """
-        mock_toggle.return_value = False
-
-        enforcer = AuthzEnforcer.get_enforcer()
-
-        self.assertFalse(AuthzEnforcer.is_auto_save_enabled())
-        self.assertFalse(enforcer.is_auto_loading_running())
-
-    @patch("openedx_authz.engine.enforcer.libraries_v2_enabled")
-    @override_settings(CASBIN_AUTO_LOAD_POLICY_INTERVAL=0.5)
-    def test_enforcer_auto_load_starts_when_toggle_enabled(self, mock_toggle):
-        """Test that auto-load starts when toggle is enabled and interval > 0.
-
-        Expected result:
-            - Auto-load thread is started with configured interval
-            - Auto-save is enabled
-        """
-        mock_toggle.return_value = True
-
-        enforcer = AuthzEnforcer.get_enforcer()
-
-        self.assertTrue(enforcer.is_auto_loading_running())
-        self.assertTrue(AuthzEnforcer.is_auto_save_enabled())
-
-    @patch("openedx_authz.engine.enforcer.libraries_v2_enabled")
-    @override_settings(CASBIN_AUTO_LOAD_POLICY_INTERVAL=0.5)
-    def test_enforcer_auto_load_not_restarted_on_subsequent_calls(self, mock_toggle):
-        """Test that auto-load is not restarted on subsequent get_enforcer() calls.
-
-        Expected result:
-            - Auto-load starts on first call
-            - Subsequent calls don't restart the auto-load thread
-            - Auto-save remains enabled
-        """
-        mock_toggle.return_value = True
-
-        enforcer1 = AuthzEnforcer.get_enforcer()
-        self.assertTrue(enforcer1.is_auto_loading_running())
-
-        enforcer2 = AuthzEnforcer.get_enforcer()
-        self.assertIs(enforcer1, enforcer2)
-        self.assertTrue(enforcer2.is_auto_loading_running())
-        self.assertTrue(AuthzEnforcer.is_auto_save_enabled())
-
-    @patch("openedx_authz.engine.enforcer.libraries_v2_enabled")
-    @override_settings(CASBIN_AUTO_LOAD_POLICY_INTERVAL=0)
-    def test_toggle_state_checked_on_every_get_enforcer_call(self, mock_toggle):
-        """Test that toggle state is checked on every get_enforcer() call.
-
-        This verifies the "HACK" behavior where the toggle state is
-        re-evaluated each time get_enforcer() is called.
-
-        Expected result:
-            - First call with toggle off: auto-save disabled
-            - Second call with toggle on: auto-save enabled
-        """
-        mock_toggle.return_value = False
-        enforcer1 = AuthzEnforcer.get_enforcer()
-        self.assertFalse(AuthzEnforcer.is_auto_save_enabled())
-
-        mock_toggle.return_value = True
-        enforcer2 = AuthzEnforcer.get_enforcer()
-        self.assertIs(enforcer1, enforcer2)
-        self.assertTrue(AuthzEnforcer.is_auto_save_enabled())
-
-    @patch("openedx_authz.engine.enforcer.libraries_v2_enabled")
-    @override_settings(CASBIN_AUTO_LOAD_POLICY_INTERVAL=0)
-    def test_dummy_toggle_behavior_in_tests(self, mock_toggle):
-        """Test enforcer behavior with DummyToggle (CMS not available).
-
-        When CMS is not available, a DummyToggle is used that always
-        returns True. This test verifies that the enforcer still works
-        correctly in this scenario.
-
-        Expected result:
-            - Enforcer initializes successfully
-            - Auto-save is enabled (DummyToggle returns True)
-        """
-        mock_toggle.return_value = True
-
-        enforcer = AuthzEnforcer.get_enforcer()
-
-        self.assertIsNotNone(enforcer)
-        self.assertTrue(AuthzEnforcer.is_auto_save_enabled())
-
-    @patch("openedx_authz.engine.enforcer.libraries_v2_enabled")
-    @override_settings(CASBIN_AUTO_LOAD_POLICY_INTERVAL=0)
-    def test_auto_save_preserved_with_interval_zero(self, mock_toggle):
-        """Test that auto-save state is preserved when interval is 0.
-
-        When CASBIN_AUTO_LOAD_POLICY_INTERVAL is 0, calling get_enforcer()
-        multiple times should not disable auto-save if it was manually enabled.
-
-        Expected result:
-            - Tests can manually enable auto-save
-            - Subsequent get_enforcer() calls preserve auto-save state
-        """
-        mock_toggle.return_value = True
-
-        enforcer = AuthzEnforcer.get_enforcer()
-        enforcer.enable_auto_save(True)
-        self.assertTrue(AuthzEnforcer.is_auto_save_enabled())
-
-        # Call get_enforcer() again - should not disable auto-save
-        enforcer2 = AuthzEnforcer.get_enforcer()
-        self.assertIs(enforcer, enforcer2)
-        self.assertTrue(AuthzEnforcer.is_auto_save_enabled())
-
-    @patch("openedx_authz.engine.enforcer.libraries_v2_enabled")
-    @override_settings(CASBIN_AUTO_LOAD_POLICY_INTERVAL=0)
-    def test_auto_save_persistence_with_interval_zero(self, mock_toggle):
-        """Test that policies persist to database when auto-save is enabled with interval 0.
-
-        Expected result:
-            - Policies added via add_policy() are persisted to database
-            - Policies can be reloaded from database
-        """
-        mock_toggle.return_value = True
-
-        enforcer = AuthzEnforcer.get_enforcer()
-        enforcer.enable_auto_save(True)
-
-        test_policy = [
-            make_role_key("test_role"),
-            make_action_key("test_action"),
-            make_scope_key("lib", "*"),
-            "allow",
-        ]
-        enforcer.add_policy(*test_policy)
-
-        # Reload from database
-        enforcer.load_policy()
-        policies = enforcer.get_policy()
-
-        self.assertIn(test_policy, policies)
-
-    @patch("openedx_authz.engine.enforcer.libraries_v2_enabled")
-    @override_settings(CASBIN_AUTO_LOAD_POLICY_INTERVAL=0, CASBIN_AUTO_SAVE_POLICY=False)
-    def test_auto_save_disabled_explicitly(self, mock_toggle):
-        """Test that auto-save is disabled when CASBIN_AUTO_SAVE_POLICY is False.
-
-        Expected result:
-            - Auto-save is disabled
-            - Auto-load is not running
-        """
-        mock_toggle.return_value = True
-
-        enforcer = AuthzEnforcer.get_enforcer()
-
-        self.assertFalse(AuthzEnforcer.is_auto_save_enabled())
-        self.assertFalse(enforcer.is_auto_loading_running())
-
-    @patch("openedx_authz.engine.enforcer.libraries_v2_enabled")
-    @override_settings(CASBIN_AUTO_LOAD_POLICY_INTERVAL=0, CASBIN_AUTO_SAVE_POLICY=False)
-    def test_policies_not_persisted_when_auto_save_disabled(self, mock_toggle):
-        """Test that policies don't persist when auto-save is explicitly disabled.
-
-        Expected result:
-            - Policies added are only in memory
-            - Reloading from database clears them
-        """
-        mock_toggle.return_value = True
-
-        enforcer = AuthzEnforcer.get_enforcer()
-
-        test_policy = [
-            make_role_key("test_role"),
-            make_action_key("test_action"),
-            make_scope_key("lib", "*"),
-            "allow",
-        ]
-        enforcer.add_policy(*test_policy)
-
-        # Policy should be in memory
-        self.assertIn(test_policy, enforcer.get_policy())
-
-        # Reload from database - should clear memory-only policy
-        enforcer.load_policy()
-        policies = enforcer.get_policy()
-
-        self.assertNotIn(test_policy, policies)
-
-    @patch("openedx_authz.engine.enforcer.libraries_v2_enabled")
-    @override_settings(CASBIN_AUTO_LOAD_POLICY_INTERVAL=0)
-    def test_multiple_get_enforcer_calls_preserve_auto_save(self, mock_toggle):
-        """Test that multiple get_enforcer() calls don't repeatedly disable auto-save.
-
-        This is a regression test for the bug where get_enforcer() would
-        disable auto-save on every call when interval was 0.
-
-        Expected result:
-            - After manually enabling auto-save, it stays enabled
-            - Multiple get_enforcer() calls don't change auto-save state
-        """
-        mock_toggle.return_value = True
-
-        # First call
-        enforcer1 = AuthzEnforcer.get_enforcer()
-        enforcer1.enable_auto_save(True)
-        self.assertTrue(AuthzEnforcer.is_auto_save_enabled())
-
-        # Multiple subsequent calls
-        for _ in range(5):
-            AuthzEnforcer.get_enforcer()
-            self.assertTrue(AuthzEnforcer.is_auto_save_enabled())
-
-
 class TestEnforcerPolicyCacheBehavior(TransactionTestCase):
     """Test cases for enforcer policy cache behavior.
 
@@ -834,16 +562,14 @@ class TestEnforcerPolicyCacheBehavior(TransactionTestCase):
     ensuring that policies are reloaded only when needed.
     """
 
-    @patch("openedx_authz.engine.enforcer.libraries_v2_enabled")
     @override_settings(CASBIN_AUTO_LOAD_POLICY_INTERVAL=0)
-    def test_load_policy_if_needed_initializes_cache_version(self, mock_toggle):
+    def test_load_policy_if_needed_initializes_cache_version(self):
         """Test that load_policy_if_needed initializes cache version on first call.
 
         Expected result:
             - On first call, cache invalidation model is initialized
             - Policy is loaded since last load version is None
         """
-        mock_toggle.return_value = True
 
         AuthzEnforcer._last_policy_loaded_version = None  # pylint: disable=protected-access
         # get_enforcer calls load_policy_if_needed internally
@@ -857,16 +583,14 @@ class TestEnforcerPolicyCacheBehavior(TransactionTestCase):
             cached_version,
         )
 
-    @patch("openedx_authz.engine.enforcer.libraries_v2_enabled")
     @override_settings(CASBIN_AUTO_LOAD_POLICY_INTERVAL=0)
-    def test_load_policy_if_needed_loads_when_stale(self, mock_toggle):
+    def test_load_policy_if_needed_loads_when_stale(self):
         """Test that load_policy_if_needed reloads policy when stale.
 
         Expected result:
             - If policy is stale, it is reloaded
             - _last_policy_loaded_version is updated with new version
         """
-        mock_toggle.return_value = True
 
         stale_version = uuid4()
         current_version = uuid4()
@@ -885,16 +609,14 @@ class TestEnforcerPolicyCacheBehavior(TransactionTestCase):
             current_version,
         )
 
-    @patch("openedx_authz.engine.enforcer.libraries_v2_enabled")
     @override_settings(CASBIN_AUTO_LOAD_POLICY_INTERVAL=0)
-    def test_load_policy_if_needed_doesnt_reload_when_not_stale(self, mock_toggle):
+    def test_load_policy_if_needed_doesnt_reload_when_not_stale(self):
         """Test that load_policy_if_needed does not reload policy when not stale.
 
         Expected result:
             - If policy is not stale, it is not reloaded
             - _last_policy_loaded_version remains unchanged
         """
-        mock_toggle.return_value = True
 
         current_version = uuid4()
 
@@ -911,15 +633,13 @@ class TestEnforcerPolicyCacheBehavior(TransactionTestCase):
             current_version,
         )
 
-    @patch("openedx_authz.engine.enforcer.libraries_v2_enabled")
     @override_settings(CASBIN_AUTO_LOAD_POLICY_INTERVAL=0)
-    def test_invalidate_policy_cache(self, mock_toggle):
+    def test_invalidate_policy_cache(self):
         """Test that invalidate_policy_cache updates the cache invalidation model.
 
         Expected result:
             - Cache invalidation key is updated to a new version
         """
-        mock_toggle.return_value = True
 
         AuthzEnforcer._last_policy_loaded_version = uuid4()  # pylint: disable=protected-access
         old_cache_value = uuid4()


### PR DESCRIPTION
This was originally added as a performance improvement when libraries v2 was disabled, but it causes downstream errors when libraries v2 data exists even if libraries v2 is disabled.

The behavior would default to true in almost every case anyway due to a circular import in the toggles check on openedx-platform.


**Merge checklist:**
Check off if complete *or* not applicable:
- [x] Version bumped
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Fixup commits are squashed away
- [x] Unit tests added/updated
- [x] Manual testing instructions provided
- [x] Noted any: Concerns, dependencies, migration issues, deadlines, tickets
