### PR TITLE
feat: add platform-level glob scope for content libraries

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,14 @@ Change Log
 Unreleased
 **********
 
+1.18.0 - 2026-06-09
+*******************
+
+Added
+=====
+
+* Add platform glob scope for content libraries.
+
 1.17.1 - 2026-06-05
 *******************
 

--- a/openedx_authz/__init__.py
+++ b/openedx_authz/__init__.py
@@ -4,6 +4,6 @@ Open edX AuthZ provides the architecture and foundations of the authorization fr
 
 import os
 
-__version__ = "1.17.1"
+__version__ = "1.18.0"
 
 ROOT_DIRECTORY = os.path.dirname(os.path.abspath(__file__))

--- a/openedx_authz/api/data.py
+++ b/openedx_authz/api/data.py
@@ -37,6 +37,7 @@ __all__ = [
     "OrgGlobData",
     "OrgContentLibraryGlobData",
     "PermissionData",
+    "PlatformContentLibraryGlobData",
     "PlatformCourseOverviewGlobData",
     "PlatformGlobData",
     "PolicyIndex",
@@ -414,7 +415,7 @@ class ScopeMeta(type):
 
         Examples:
             >>> ScopeMeta.get_all_platform_glob_namespaces()
-            {'course-v1': PlatformCourseOverviewGlobData}
+            {'course-v1': PlatformCourseOverviewGlobData, 'lib': PlatformContentLibraryGlobData}
         """
         return mcs.platform_glob_registry
 
@@ -428,7 +429,13 @@ class ScopeMeta(type):
 
         Examples:
             >>> ScopeMeta.get_all_registered_scopes()
-            [ScopeData, ContentLibraryData, OrgCourseOverviewGlobData, PlatformCourseOverviewGlobData]
+            [
+                ScopeData,
+                ContentLibraryData,
+                OrgCourseOverviewGlobData,
+                PlatformContentLibraryGlobData,
+                PlatformCourseOverviewGlobData,
+            ]
         """
         return list(
             {
@@ -1225,6 +1232,60 @@ class PlatformCourseOverviewGlobData(PlatformGlobData):
             PermissionData: The permission required to manage this scope in the admin console.
         """
         return COURSES_MANAGE_COURSE_TEAM
+
+
+@define
+class PlatformContentLibraryGlobData(PlatformGlobData):
+    """Platform-level glob pattern for content libraries.
+
+    This class represents glob patterns that match all content libraries in the platform.
+    Format: ``lib:*``
+
+    The glob pattern allows granting permissions to all libraries across the entire
+    platform without needing to specify organizations or individual libraries.
+
+    Attributes:
+        NAMESPACE (str): 'lib' for content library scopes.
+        IS_PLATFORM_GLOB (bool): True for scope data that represents a platform-level glob pattern.
+        external_key (str): The glob pattern (always ``lib:*``).
+        namespaced_key (str): The pattern with namespace (``lib^lib:*``).
+
+    Validation Rules:
+        - Must be exactly ``lib:*``
+        - Applies to all existing and future libraries in the platform
+        - Does not grant access to other resource types
+
+    Examples:
+        >>> glob = PlatformContentLibraryGlobData(external_key='lib:*')
+        >>> glob.exists()
+        True
+        >>> glob.namespaced_key
+        'lib^lib:*'
+
+    Note:
+        This class is automatically instantiated by the ScopeMeta metaclass when
+        a library scope with the platform wildcard is created.
+    """
+
+    NAMESPACE: ClassVar[str] = "lib"
+
+    @classmethod
+    def get_admin_view_permission(cls) -> PermissionData:
+        """Get the permission required to view this scope.
+
+        Returns:
+            PermissionData: The permission required to view this scope in the admin console.
+        """
+        return VIEW_LIBRARY_TEAM
+
+    @classmethod
+    def get_admin_manage_permission(cls) -> PermissionData:
+        """Get the permission required to manage this scope.
+
+        Returns:
+            PermissionData: The permission required to manage this scope in the admin console.
+        """
+        return MANAGE_LIBRARY_TEAM
 
 
 class CCXCourseOverviewData(CourseOverviewData):

--- a/openedx_authz/api/users.py
+++ b/openedx_authz/api/users.py
@@ -331,9 +331,7 @@ def _filter_allowed_assignments(
     if is_user_staff_or_superuser(user_external_key):
         return assignments
 
-    return filter_role_assignments_visible_to_subject(
-        UserData(external_key=user_external_key), assignments
-    )
+    return filter_role_assignments_visible_to_subject(UserData(external_key=user_external_key), assignments)
 
 
 def get_visible_role_assignments_for_user(

--- a/openedx_authz/engine/matcher.py
+++ b/openedx_authz/engine/matcher.py
@@ -5,6 +5,7 @@ from openedx_authz.api.data import (
     CourseOverviewData,
     OrgContentLibraryGlobData,
     OrgCourseOverviewGlobData,
+    PlatformContentLibraryGlobData,
     PlatformCourseOverviewGlobData,
     ScopeData,
     UserData,
@@ -16,6 +17,7 @@ SCOPES_WITH_ADMIN_OR_SUPERUSER_CHECK = {
     (CourseOverviewData.NAMESPACE, CourseOverviewData),
     (OrgContentLibraryGlobData.NAMESPACE, OrgContentLibraryGlobData),
     (OrgCourseOverviewGlobData.NAMESPACE, OrgCourseOverviewGlobData),
+    (PlatformContentLibraryGlobData.NAMESPACE, PlatformContentLibraryGlobData),
     (PlatformCourseOverviewGlobData.NAMESPACE, PlatformCourseOverviewGlobData),
 }
 

--- a/openedx_authz/tests/api/test_data.py
+++ b/openedx_authz/tests/api/test_data.py
@@ -1236,9 +1236,7 @@ class TestPlatformContentLibraryGlobData(TestCase):
 
     def test_get_admin_view_permission(self):
         """View permission matches library team view permission."""
-        self.assertEqual(
-            PlatformContentLibraryGlobData.get_admin_view_permission(), permissions.VIEW_LIBRARY_TEAM
-        )
+        self.assertEqual(PlatformContentLibraryGlobData.get_admin_view_permission(), permissions.VIEW_LIBRARY_TEAM)
 
     def test_get_admin_manage_permission(self):
         """Manage permission matches library team manage permission."""

--- a/openedx_authz/tests/api/test_data.py
+++ b/openedx_authz/tests/api/test_data.py
@@ -14,6 +14,7 @@ from openedx_authz.api.data import (
     OrgContentLibraryGlobData,
     OrgCourseOverviewGlobData,
     PermissionData,
+    PlatformContentLibraryGlobData,
     PlatformCourseOverviewGlobData,
     RoleAssignmentData,
     RoleData,
@@ -271,12 +272,15 @@ class TestScopeMetaClass(TestCase):
         # Glob registries for platform-level scopes
         self.assertIn("course-v1", ScopeMeta.platform_glob_registry)
         self.assertIs(ScopeMeta.platform_glob_registry["course-v1"], PlatformCourseOverviewGlobData)
+        self.assertIn("lib", ScopeMeta.platform_glob_registry)
+        self.assertIs(ScopeMeta.platform_glob_registry["lib"], PlatformContentLibraryGlobData)
 
     @data(
         ("ccx-v1^ccx-v1:OpenedX+DemoX+DemoCourse+ccx@1", CCXCourseOverviewData),
         ("course-v1^course-v1:WGU+CS002+2025_T1", CourseOverviewData),
         ("lib^lib:DemoX:CSPROB", ContentLibraryData),
         ("lib^lib:DemoX*", OrgContentLibraryGlobData),
+        ("lib^lib:*", PlatformContentLibraryGlobData),
         ("course-v1^course-v1:OpenedX*", OrgCourseOverviewGlobData),
         ("course-v1^course-v1:*", PlatformCourseOverviewGlobData),
         ("global^generic_scope", ScopeData),
@@ -299,6 +303,7 @@ class TestScopeMetaClass(TestCase):
         ("course-v1^course-v1:WGU+CS002+2025_T1", CourseOverviewData),
         ("lib^lib:DemoX:CSPROB", ContentLibraryData),
         ("lib^lib:DemoX:*", OrgContentLibraryGlobData),
+        ("lib^lib:*", PlatformContentLibraryGlobData),
         ("course-v1^course-v1:OpenedX+*", OrgCourseOverviewGlobData),
         ("course-v1^course-v1:*", PlatformCourseOverviewGlobData),
         ("lib^*", ScopeData),
@@ -458,6 +463,7 @@ class TestScopeMetaClass(TestCase):
         ("course-v1:WGU+CS002+2025_T1", CourseOverviewData),
         ("lib:DemoX:CSPROB", ContentLibraryData),
         ("lib:DemoX:*", OrgContentLibraryGlobData),
+        ("lib:*", PlatformContentLibraryGlobData),
         ("course-v1:OpenedX+*", OrgCourseOverviewGlobData),
         ("course-v1:*", PlatformCourseOverviewGlobData),
         ("lib:edX:Demo", ContentLibraryData),
@@ -537,8 +543,11 @@ class TestScopeMetaClass(TestCase):
     def test_platform_glob_registration_does_not_override_scope_registry(self):
         """Platform globs register separately; concrete scopes keep scope_registry entries."""
         self.assertIs(ScopeData.scope_registry["course-v1"], CourseOverviewData)
+        self.assertIs(ScopeData.scope_registry["lib"], ContentLibraryData)
         self.assertIs(ScopeMeta.platform_glob_registry["course-v1"], PlatformCourseOverviewGlobData)
+        self.assertIs(ScopeMeta.platform_glob_registry["lib"], PlatformContentLibraryGlobData)
         self.assertNotIn(PlatformCourseOverviewGlobData, ScopeData.scope_registry.values())
+        self.assertNotIn(PlatformContentLibraryGlobData, ScopeData.scope_registry.values())
 
     def test_platform_glob_resolves_before_org_glob_for_course_namespace(self):
         """course-v1:* is a platform glob; course-v1:Org+* remains an org glob."""
@@ -557,16 +566,32 @@ class TestScopeMetaClass(TestCase):
         self.assertEqual(scope.external_key, "course-v1:*")
         self.assertEqual(scope.namespaced_key, "course-v1^course-v1:*")
 
+    def test_platform_glob_resolves_before_org_glob_for_lib_namespace(self):
+        """lib:* is a platform glob; lib:Org:* remains an org glob."""
+        self.assertIs(ScopeMeta.get_subclass_by_external_key("lib:*"), PlatformContentLibraryGlobData)
+        self.assertIs(ScopeMeta.get_subclass_by_external_key("lib:DemoX:*"), OrgContentLibraryGlobData)
+        self.assertIs(ScopeMeta.get_subclass_by_namespaced_key("lib^lib:*"), PlatformContentLibraryGlobData)
+        self.assertIs(ScopeMeta.get_subclass_by_namespaced_key("lib^lib:DemoX:*"), OrgContentLibraryGlobData)
+
+    def test_dynamic_instantiation_via_external_key_for_lib_platform_glob(self):
+        """ScopeData(external_key='lib:*') instantiates PlatformContentLibraryGlobData."""
+        scope = ScopeData(external_key="lib:*")
+
+        self.assertIsInstance(scope, PlatformContentLibraryGlobData)
+        self.assertEqual(scope.external_key, "lib:*")
+        self.assertEqual(scope.namespaced_key, "lib^lib:*")
+
     def test_get_subclass_by_external_key_unknown_platform_glob_raises_value_error(self):
         """Namespace:* without a registered platform glob subclass raises ValueError."""
         with self.assertRaisesRegex(ValueError, "Unknown platform glob scope"):
-            ScopeMeta.get_subclass_by_external_key("lib:*")
+            ScopeMeta.get_subclass_by_external_key("ccx-v1:*")
 
     def test_get_all_registered_scopes_includes_platform_glob(self):
         """get_all_registered_scopes returns platform glob subclasses."""
         registered = ScopeMeta.get_all_registered_scopes()
 
         self.assertIn(PlatformCourseOverviewGlobData, registered)
+        self.assertIn(PlatformContentLibraryGlobData, registered)
         self.assertIn(OrgCourseOverviewGlobData, registered)
         self.assertIn(CourseOverviewData, registered)
 
@@ -1157,3 +1182,79 @@ class TestPlatformCourseOverviewGlobData(TestCase):
 
         self.assertIn("course-v1", platform_globs)
         self.assertIs(platform_globs["course-v1"], PlatformCourseOverviewGlobData)
+
+
+@ddt
+class TestPlatformContentLibraryGlobData(TestCase):
+    """Tests for the PlatformContentLibraryGlobData scope."""
+
+    PLATFORM_GLOB_EXTERNAL_KEY = "lib:*"
+    PLATFORM_GLOB_NAMESPACED_KEY = "lib^lib:*"
+
+    def test_build_external_key(self):
+        """build_external_key returns the platform-wide library glob pattern."""
+        self.assertEqual(PlatformContentLibraryGlobData.build_external_key(), self.PLATFORM_GLOB_EXTERNAL_KEY)
+
+    @data(
+        ("lib:*", True),
+        ("lib:DemoX:*", False),
+        ("lib:DemoX*", False),
+        ("lib:DemoX", False),
+        ("lib:*:*", False),
+        ("other:*", False),
+        ("course-v1:*", False),
+    )
+    @unpack
+    def test_validate_external_key(self, external_key, expected_valid):
+        """Validate platform-level library glob external keys."""
+        self.assertEqual(PlatformContentLibraryGlobData.validate_external_key(external_key), expected_valid)
+
+    def test_exists_always_true(self):
+        """exists() returns True without checking the database."""
+        scope = PlatformContentLibraryGlobData(external_key=self.PLATFORM_GLOB_EXTERNAL_KEY)
+
+        self.assertTrue(scope.exists())
+
+    def test_get_object_returns_none(self):
+        """Platform glob scopes do not map to a concrete domain object."""
+        scope = PlatformContentLibraryGlobData(external_key=self.PLATFORM_GLOB_EXTERNAL_KEY)
+
+        self.assertIsNone(scope.get_object())
+
+    def test_namespaced_key(self):
+        """namespaced_key includes namespace prefix and external key."""
+        scope = PlatformContentLibraryGlobData(external_key=self.PLATFORM_GLOB_EXTERNAL_KEY)
+
+        self.assertEqual(scope.namespaced_key, self.PLATFORM_GLOB_NAMESPACED_KEY)
+
+    def test_dynamic_instantiation_via_scope_data(self):
+        """ScopeData resolves lib:* to PlatformContentLibraryGlobData."""
+        scope = ScopeData(external_key=self.PLATFORM_GLOB_EXTERNAL_KEY)
+
+        self.assertIsInstance(scope, PlatformContentLibraryGlobData)
+        self.assertEqual(scope.external_key, self.PLATFORM_GLOB_EXTERNAL_KEY)
+
+    def test_get_admin_view_permission(self):
+        """View permission matches library team view permission."""
+        self.assertEqual(
+            PlatformContentLibraryGlobData.get_admin_view_permission(), permissions.VIEW_LIBRARY_TEAM
+        )
+
+    def test_get_admin_manage_permission(self):
+        """Manage permission matches library team manage permission."""
+        self.assertEqual(
+            PlatformContentLibraryGlobData.get_admin_manage_permission(),
+            permissions.MANAGE_LIBRARY_TEAM,
+        )
+
+    def test_is_platform_glob(self):
+        """Platform library glob is flagged as a platform-level glob scope."""
+        self.assertTrue(PlatformContentLibraryGlobData.IS_PLATFORM_GLOB)
+        self.assertFalse(PlatformContentLibraryGlobData.IS_ORG_GLOB)
+
+    def test_get_all_platform_glob_namespaces(self):
+        """Platform glob namespace is registered in ScopeMeta."""
+        platform_globs = ScopeMeta.get_all_platform_glob_namespaces()
+
+        self.assertIn("lib", platform_globs)
+        self.assertIs(platform_globs["lib"], PlatformContentLibraryGlobData)

--- a/openedx_authz/tests/api/test_roles.py
+++ b/openedx_authz/tests/api/test_roles.py
@@ -1536,9 +1536,7 @@ class TestFilterRoleAssignmentsVisibleToSubject(RolesTestSetupMixin):
         """
         all_assignments = get_all_subject_role_assignments()
 
-        visible = filter_role_assignments_visible_to_subject(
-            SubjectData(external_key="alice"), all_assignments
-        )
+        visible = filter_role_assignments_visible_to_subject(SubjectData(external_key="alice"), all_assignments)
 
         visible_scopes = {a.scope.external_key for a in visible}
         self.assertIn("lib:Org1:math_101", visible_scopes)
@@ -1551,9 +1549,7 @@ class TestFilterRoleAssignmentsVisibleToSubject(RolesTestSetupMixin):
         """
         all_assignments = get_all_subject_role_assignments()
 
-        visible = filter_role_assignments_visible_to_subject(
-            SubjectData(external_key="alice"), all_assignments
-        )
+        visible = filter_role_assignments_visible_to_subject(SubjectData(external_key="alice"), all_assignments)
 
         visible_scopes = {a.scope.external_key for a in visible}
         self.assertNotIn("lib:Org2:physics_401", visible_scopes)
@@ -1567,9 +1563,7 @@ class TestFilterRoleAssignmentsVisibleToSubject(RolesTestSetupMixin):
         """
         all_assignments = get_all_subject_role_assignments()
 
-        visible = filter_role_assignments_visible_to_subject(
-            SubjectData(external_key="unknown_user"), all_assignments
-        )
+        visible = filter_role_assignments_visible_to_subject(SubjectData(external_key="unknown_user"), all_assignments)
 
         self.assertEqual(visible, [])
 
@@ -1579,8 +1573,6 @@ class TestFilterRoleAssignmentsVisibleToSubject(RolesTestSetupMixin):
         Expected result:
             - Result is empty regardless of the subject's accessible scopes.
         """
-        visible = filter_role_assignments_visible_to_subject(
-            SubjectData(external_key="alice"), []
-        )
+        visible = filter_role_assignments_visible_to_subject(SubjectData(external_key="alice"), [])
 
         self.assertEqual(visible, [])

--- a/openedx_authz/tests/rest_api/test_views.py
+++ b/openedx_authz/tests/rest_api/test_views.py
@@ -20,6 +20,7 @@ from openedx_authz.api.data import (
     CourseOverviewData,
     OrgContentLibraryGlobData,
     OrgCourseOverviewGlobData,
+    PlatformContentLibraryGlobData,
     PlatformCourseOverviewGlobData,
 )
 from openedx_authz.api.users import assign_role_to_user_in_scope
@@ -39,6 +40,9 @@ User = get_user_model()
 COURSE_SCOPE_ORG1 = "course-v1:Org1+COURSE1+2024"
 COURSE_ORG1_GLOB = OrgCourseOverviewGlobData.build_external_key(CourseOverviewData(external_key=COURSE_SCOPE_ORG1).org)
 PLATFORM_COURSE_GLOB = PlatformCourseOverviewGlobData.build_external_key()
+LIB_SCOPE_ORG1 = "lib:Org1:LIB1"
+LIB_ORG1_GLOB = OrgContentLibraryGlobData.build_external_key("Org1")
+PLATFORM_LIBRARY_GLOB = PlatformContentLibraryGlobData.build_external_key()
 
 
 class ViewTestMixin(BaseRolesTestCase):
@@ -155,12 +159,20 @@ class ViewTestMixin(BaseRolesTestCase):
             User.objects.get_or_create(username=username, defaults={"email": f"{username}@example.com"})
 
     @classmethod
+    def create_library_users(cls):
+        """Create library users (plain, non-staff)."""
+        users = ["library_admin", "library_admin_org", "library_admin_platform"]
+        for username in users:
+            User.objects.get_or_create(username=username, defaults={"email": f"{username}@example.com"})
+
+    @classmethod
     def setUpTestData(cls):
         """Set up test fixtures once for the entire test class."""
         super().setUpTestData()
         cls.create_admin_users(quantity=3)
         cls.create_regular_users(quantity=10)
         cls.create_course_users()
+        cls.create_library_users()
 
     def setUp(self):
         """Set up test fixtures."""
@@ -4213,5 +4225,96 @@ class TestBulkPutScopesAllLogic(ViewTestMixin):
         self.client.force_authenticate(user=user)
 
         response = self._put_course(scopes)
+
+        self.assertEqual(response.status_code, expected_status)
+
+
+@ddt
+class TestPlatformGlobLibraryRoleAssignment(ViewTestMixin):
+    """Test that a platform-level library_admin can assign library roles at lib:*.
+
+    Three users illustrate the difference between specific-scope, org-level, and
+    platform-level library permissions:
+      - library_admin: LIBRARY_ADMIN on LIB_SCOPE_ORG1 only (specific library).
+      - library_admin_org: LIBRARY_ADMIN on LIB_ORG1_GLOB (all libraries in Org1).
+      - library_admin_platform: LIBRARY_ADMIN on PLATFORM_LIBRARY_GLOB (all libraries).
+    """
+
+    _LIBRARY_ASSIGNMENTS = [
+        {
+            "subject_name": "library_admin",
+            "role_name": roles.LIBRARY_ADMIN.external_key,
+            "scope_name": LIB_SCOPE_ORG1,
+        },
+        {
+            "subject_name": "library_admin_org",
+            "role_name": roles.LIBRARY_ADMIN.external_key,
+            "scope_name": LIB_ORG1_GLOB,
+        },
+        {
+            "subject_name": "library_admin_platform",
+            "role_name": roles.LIBRARY_ADMIN.external_key,
+            "scope_name": PLATFORM_LIBRARY_GLOB,
+        },
+    ]
+
+    def setUp(self):
+        super().setUp()
+        self.url = reverse("openedx_authz:role-user-list")
+        self._assign_roles_to_users(assignments=self._LIBRARY_ASSIGNMENTS)
+
+    def _put_lib(self, scopes, role):
+        """Send a bulk PUT assigning the given library role for the given scopes."""
+        request_data = {"role": role, "scopes": scopes, "users": ["regular_2"]}
+        with (
+            patch.object(api.ContentLibraryData, "exists", return_value=True),
+            patch.object(api.OrgContentLibraryGlobData, "exists", return_value=True),
+            patch.object(api.PlatformContentLibraryGlobData, "exists", return_value=True),
+        ):
+            return self.client.put(self.url, data=request_data, format="json")
+
+    @data(
+        roles.LIBRARY_ADMIN.external_key,
+        roles.LIBRARY_AUTHOR.external_key,
+        roles.LIBRARY_CONTRIBUTOR.external_key,
+        roles.LIBRARY_USER.external_key,
+    )
+    def test_platform_library_admin_can_assign_any_role_globally(self, role):
+        """A platform library_admin can assign any library role at lib:*."""
+        user = User.objects.get(username="library_admin_platform")
+        self.client.force_authenticate(user=user)
+
+        response = self._put_lib([PLATFORM_LIBRARY_GLOB], role)
+
+        self.assertEqual(response.status_code, status.HTTP_207_MULTI_STATUS)
+        self.assertEqual(len(response.data["completed"]), 1)
+        self.assertEqual(response.data["completed"][0]["scope"], PLATFORM_LIBRARY_GLOB)
+
+    @data(
+        # library_admin and library_admin_org lack permission at the platform glob.
+        ("library_admin", [PLATFORM_LIBRARY_GLOB], status.HTTP_403_FORBIDDEN),
+        ("library_admin", [LIB_SCOPE_ORG1, PLATFORM_LIBRARY_GLOB], status.HTTP_403_FORBIDDEN),
+        ("library_admin_org", [PLATFORM_LIBRARY_GLOB], status.HTTP_403_FORBIDDEN),
+        ("library_admin_org", [LIB_ORG1_GLOB, PLATFORM_LIBRARY_GLOB], status.HTTP_403_FORBIDDEN),
+        # library_admin_platform has LIBRARY_ADMIN on the platform glob.
+        # Via Casbin glob matching, this covers the platform glob and any org or library scope.
+        ("library_admin_platform", [PLATFORM_LIBRARY_GLOB], status.HTTP_207_MULTI_STATUS),
+        ("library_admin_platform", [LIB_ORG1_GLOB], status.HTTP_207_MULTI_STATUS),
+        ("library_admin_platform", [LIB_SCOPE_ORG1], status.HTTP_207_MULTI_STATUS),
+        ("library_admin_platform", [PLATFORM_LIBRARY_GLOB, LIB_ORG1_GLOB], status.HTTP_207_MULTI_STATUS),
+    )
+    @unpack
+    def test_scope_permission_vs_platform_permission(self, username, scopes, expected_status):
+        """Users with library- or org-level roles cannot assign at the platform glob.
+
+        library_admin (specific scope) and library_admin_org (org glob) fail on any scope
+        list that includes the platform glob, because they have no permission at that level.
+        library_admin_platform (platform glob) passes for the platform glob and any org or
+        specific library within it, thanks to Casbin's glob matching.
+        """
+        user = User.objects.get(username=username)
+        self.client.force_authenticate(user=user)
+
+        response = self._put_lib(scopes, roles.LIBRARY_ADMIN.external_key)
 
         self.assertEqual(response.status_code, expected_status)

--- a/openedx_authz/tests/test_enforcement.py
+++ b/openedx_authz/tests/test_enforcement.py
@@ -666,9 +666,7 @@ class PlatformGlobLibraryEnforcementTests(CasbinEnforcementTestCase):
     all organizations on the platform.
     """
 
-    POLICIES = [
-        make_policy(roles.LIBRARY_ADMIN.external_key, VIEW_LIBRARY.identifier, ContentLibraryData.NAMESPACE)
-    ]
+    POLICIES = [make_policy(roles.LIBRARY_ADMIN.external_key, VIEW_LIBRARY.identifier, ContentLibraryData.NAMESPACE)]
 
     ASSIGNMENTS = [
         make_library_assignment("user1", roles.LIBRARY_ADMIN.external_key, "lib:*"),

--- a/openedx_authz/tests/test_enforcement.py
+++ b/openedx_authz/tests/test_enforcement.py
@@ -656,6 +656,41 @@ class PlatformGlobCourseEnforcementTests(CasbinEnforcementTestCase):
         self._test_enforcement(self.POLICIES + self.ASSIGNMENTS, request)
 
 
+@ddt
+class PlatformGlobLibraryEnforcementTests(CasbinEnforcementTestCase):
+    """
+    Tests for platform-level glob patterns in library scopes.
+
+    This test class verifies that policies defined with platform-level glob patterns
+    (e.g., ``lib:*``) are correctly enforced for concrete library scopes across
+    all organizations on the platform.
+    """
+
+    POLICIES = [
+        make_policy(roles.LIBRARY_ADMIN.external_key, VIEW_LIBRARY.identifier, ContentLibraryData.NAMESPACE)
+    ]
+
+    ASSIGNMENTS = [
+        make_library_assignment("user1", roles.LIBRARY_ADMIN.external_key, "lib:*"),
+    ]
+
+    CASES = [
+        # Permission granted across organizations
+        make_library_case("user1", VIEW_LIBRARY.identifier, "lib:OpenedX:CS101", True),
+        make_library_case("user1", VIEW_LIBRARY.identifier, "lib:OtherOrg:CS102", True),
+        make_library_case("user1", VIEW_LIBRARY.identifier, "lib:InexistentOrg:CS500", True),
+        make_library_case("user1", VIEW_LIBRARY.identifier, "lib:OpenedXv2:Demo", True),
+        # Permission denied
+        make_library_case("user1", MANAGE_LIBRARY_TEAM.identifier, "lib:OpenedX:CS101", False),
+        make_library_case("user2", VIEW_LIBRARY.identifier, "lib:OpenedX:CS101", False),
+    ]
+
+    @data(*CASES)
+    def test_platform_level_glob_enforcement(self, request: AuthRequest):
+        """Test that platform-level glob patterns in library scopes are enforced correctly."""
+        self._test_enforcement(self.POLICIES + self.ASSIGNMENTS, request)
+
+
 @pytest.mark.django_db
 @ddt
 class StaffSuperuserAccessTests(CasbinEnforcementTestCase):
@@ -859,6 +894,25 @@ class AdminOrSuperuserMatcherTests(CasbinEnforcementTestCase):
             make_course_key("course-v1:*"),
             False,
         ),
+        # PlatformContentLibraryGlobData scope
+        (
+            make_user_key("staff_user"),
+            make_action_key("content_libraries.view_library"),
+            make_library_key("lib:*"),
+            True,
+        ),
+        (
+            make_user_key("superuser"),
+            make_action_key("content_libraries.view_library"),
+            make_library_key("lib:*"),
+            True,
+        ),
+        (
+            make_user_key("regular_user"),
+            make_action_key("content_libraries.view_library"),
+            make_library_key("lib:*"),
+            False,
+        ),
     )
     @unpack
     def test_is_admin_or_superuser_check(
@@ -872,8 +926,8 @@ class AdminOrSuperuserMatcherTests(CasbinEnforcementTestCase):
 
         Verifies that:
         - Staff users are always allowed for ContentLibraryData, CourseOverviewData,
-          OrgContentLibraryGlobData, OrgCourseOverviewGlobData, and
-          PlatformCourseOverviewGlobData scopes.
+          OrgContentLibraryGlobData, OrgCourseOverviewGlobData,
+          PlatformContentLibraryGlobData, and PlatformCourseOverviewGlobData scopes.
         - Superusers are always allowed for the same scopes.
         - Regular users are denied when they have no role assignments.
         - Unsupported scope types (e.g., org) are denied even for staff/superusers.

--- a/openedx_authz/tests/test_enforcement.py
+++ b/openedx_authz/tests/test_enforcement.py
@@ -666,21 +666,29 @@ class PlatformGlobLibraryEnforcementTests(CasbinEnforcementTestCase):
     all organizations on the platform.
     """
 
-    POLICIES = [make_policy(roles.LIBRARY_ADMIN.external_key, VIEW_LIBRARY.identifier, ContentLibraryData.NAMESPACE)]
+    POLICIES = [
+        make_policy(roles.LIBRARY_ADMIN.external_key, VIEW_LIBRARY.identifier, ContentLibraryData.NAMESPACE),
+        make_policy(roles.LIBRARY_ADMIN.external_key, MANAGE_LIBRARY_TEAM.identifier, ContentLibraryData.NAMESPACE),
+    ]
 
     ASSIGNMENTS = [
         make_library_assignment("user1", roles.LIBRARY_ADMIN.external_key, "lib:*"),
     ]
 
     CASES = [
-        # Permission granted across organizations
+        # Permission granted
+        make_library_case("user1", MANAGE_LIBRARY_TEAM.identifier, "lib:*", True),
+        make_library_case("user1", MANAGE_LIBRARY_TEAM.identifier, "lib:OpenedX:*", True),
+        make_library_case("user1", MANAGE_LIBRARY_TEAM.identifier, "lib:OtherOrg:*", True),
+        make_library_case("user1", MANAGE_LIBRARY_TEAM.identifier, "lib:InexistentOrg:*", True),
+        make_library_case("user1", MANAGE_LIBRARY_TEAM.identifier, "lib:OpenedXv2:*", True),
         make_library_case("user1", VIEW_LIBRARY.identifier, "lib:OpenedX:CS101", True),
         make_library_case("user1", VIEW_LIBRARY.identifier, "lib:OtherOrg:CS102", True),
         make_library_case("user1", VIEW_LIBRARY.identifier, "lib:InexistentOrg:CS500", True),
         make_library_case("user1", VIEW_LIBRARY.identifier, "lib:OpenedXv2:Demo", True),
         # Permission denied
-        make_library_case("user1", MANAGE_LIBRARY_TEAM.identifier, "lib:OpenedX:CS101", False),
         make_library_case("user2", VIEW_LIBRARY.identifier, "lib:OpenedX:CS101", False),
+        make_library_case("user2", MANAGE_LIBRARY_TEAM.identifier, "lib:OpenedX:CS101", False),
     ]
 
     @data(*CASES)


### PR DESCRIPTION
Resolves: https://github.com/openedx/openedx-authz/issues/307

## Description

Add `PlatformContentLibraryGlobData`, a platform-level glob scope for content libraries, completing the library counterpart to the existing `PlatformCourseOverviewGlobData`

### Example scope keys

Pattern | Type | Meaning
-- | -- | --
`lib:*` | Platform glob | All libraries on the platform
`lib:OpenedX:*` | Org glob | All libraries in org `OpenedX`
`lib:OpenedX:Demo` | Concrete | Single library

### Related PR

- https://github.com/openedx/openedx-platform/pull/38660

## Testing Instructions

To test these changes, you can check the REST API.

1. Use the `/api/authz/v1/roles/users/` endpoint to add platform content library permissions:
    
    ```json
    {
        "users": ["john"],
        "role": "library_admin",
        "scopes": ["lib:*"]
    }
    ```
2. Validate the permissions `/api/authz/v1/permissions/validate/me`
    
    ```json
    [
        {
            "action": "content_libraries.view_library",
            "scope": "lib:OpenedX:CSPROB"
        },
        {
            "action": "content_libraries.manage_library_team",
            "scope": "lib:OpenedX:CSPROB2"
        },
        {
            "action": "content_libraries.edit_library_collection",
            "scope": "lib:any-org:any-slug"
        }
    ]
    ```

**Response**

```json
[
    {
        "action": "content_libraries.view_library",
        "scope": "lib:OpenedX:CSPROB",
        "allowed": true
    },
    {
        "action": "content_libraries.manage_library_team",
        "scope": "lib:OpenedX:CSPROB2",
        "allowed": true
    },
    {
        "action": "content_libraries.edit_library_collection",
        "scope": "lib:any-org:any-slug",
        "allowed": true
    }
]
```

## Merge checklist
Check off if complete *or* not applicable:
- [x] Version bumped
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Fixup commits are squashed away
- [x] Unit tests added/updated
- [x] Manual testing instructions provided
- [x] Noted any: Concerns, dependencies, migration issues, deadlines, tickets
