### PR TITLE
fix: update missmatch param in queryset_builder for scopes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,14 @@ Change Log
 Unreleased
 **********
 
+1.21.1 - 2026-07-24
+*******************
+
+Fixed
+=====
+
+* Corrected a mismatched parameter in the queryset builder for scopes.
+
 1.21.0 - 2026-07-14
 *******************
 

--- a/openedx_authz/__init__.py
+++ b/openedx_authz/__init__.py
@@ -4,6 +4,6 @@ Open edX AuthZ provides the architecture and foundations of the authorization fr
 
 import os
 
-__version__ = "1.21.0"
+__version__ = "1.21.1"
 
 ROOT_DIRECTORY = os.path.dirname(os.path.abspath(__file__))

--- a/openedx_authz/rest_api/v1/views.py
+++ b/openedx_authz/rest_api/v1/views.py
@@ -840,7 +840,7 @@ class ScopesAPIView(generics.ListAPIView):
 
         has_platform_access = any(isinstance(s, PlatformGlobData) for s in allowed_scopes)
         if has_platform_access:
-            return queryset_builder(allowed_ids=None, allowed_orgs=None, search=search, orgs=orgs)
+            return queryset_builder(search=search, orgs=orgs)
 
         specific_scopes = [s for s in allowed_scopes if not s.IS_GLOB]
         allowed_ids = extract_ids(specific_scopes)


### PR DESCRIPTION
### Description

`_get_allowed_scope_queryset` is generic over two builders whose first parameter differs by design — `_get_courses_queryset(allowed_ids=…)` vs `_get_libraries_queryset(allowed_pairs=…)` (libraries key on org+slug pairs). The normal path (line 848) passes that arg positionally, so it works for both. But the platform-access shortcut at line 843 passed it as the keyword `allowed_ids=None`, which the libraries builder doesn't accept; hence the `TypeError`, triggered only when the requesting user has platform-wide access.


<img width="1468" height="973" alt="image" src="https://github.com/user-attachments/assets/618fc3e4-97c9-4904-b4bf-94714899d8be" />


### Testing instructions

- For reproducing the error use a user with platform-wide permissions and without Django roles. 
- Use the API to fetch the scopes http://local.openedx.io:8000/api-docs/#/authz/authz_v1_scopes_list
- See 500 error status returned.
- Swap to the current branch and re-launch the request.
- The API should return the scope list. 

**Merge checklist:**
Check off if complete *or* not applicable:
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Fixup commits are squashed away
- [ ] Unit tests added/updated
- [ ] Manual testing instructions provided
- [ ] Noted any: Concerns, dependencies, migration issues, deadlines, tickets
